### PR TITLE
Typo severals -> several in Invoking doc

### DIFF
--- a/doc/Invoking_GHDL.rst
+++ b/doc/Invoking_GHDL.rst
@@ -24,7 +24,7 @@ Analysis command
 
 .. index:: -a command
 
-Analyze one or severals files::
+Analyze one or several files::
 
   ghdl -a [options...] file...
 


### PR DESCRIPTION
Vim saw it for me, so I had to make a PR :-)