### PR TITLE
Reworked vendor library compile scripts for Altera, Lattice and Xilinx as well as OSVVM and VUnit.

### DIFF
--- a/libraries/vendors/README.md
+++ b/libraries/vendors/README.md
@@ -1,10 +1,16 @@
 ## Compile Scripts for Vendor VHDL Libraries
 
-Vendors like Altera and Xilinx have there own simulation libraries, especially for primitives, soft or hard macros. These libraries can not be shipped with GHDL, but we offer prepared compile scripts to pre-compile a vendor library, if the vendor tool is present on the computer.
+Vendors like Altera and Xilinx have there own simulation libraries, especially
+for primitives, soft or hard macros. These libraries can not be shipped with
+GHDL, but we offer prepared compile scripts to pre-compile a vendor library,
+if the vendor tool is present on the computer.
 
-There are also popular simulation and verification libraries like [OSVVM][osvvm] and [VUnit][vunit], which can be pre-compile.
+There are also popular simulation and verification libraries like [OSVVM][osvvm]
+and [VUnit][vunit], which can be pre-compile.
 
-The compilation scripts are writen in shell languages: PowerShell for Windows and Bash for Linux. The compile scripts can colorize the GHDL warning and error lines with the help of grc ([generic colourizer][grc]).
+The compilation scripts are writen in shell languages: PowerShell for Windows
+and Bash for Linux. The compile scripts can colorize the GHDL warning and error
+lines with the help of grc ([generic colourizer][grc]).
 
  [osvvm]: http://osvvm.org/
  [vunit]: https://github.com/LarsAsplund/vunit
@@ -12,7 +18,7 @@ The compilation scripts are writen in shell languages: PowerShell for Windows an
 
 ##### Supported Vendors Libraries
 
- - Altera Quartus-II (15.x):
+ - Altera Quartus (13.x):
      - lpm, sgate
      - altera, altera_mf, altera_lnsim
      - arriaii, arriaii_pcie_hip, arriaiigz
@@ -126,9 +132,9 @@ The compilation scripts are writen in shell languages: PowerShell for Windows an
     ----           -------------       ------ ----
     d----    20.11.2015    19:33        <DIR> altera
     d----    20.11.2015    19:38        <DIR> osvvm
-    d----    20.11.2015    19:40        <DIR> vivado
-    d----    20.11.2015    19:45        <DIR> vunit
-    d----    20.11.2015    19:06        <DIR> xilinx
+    d----    20.11.2015    19:45        <DIR> vunit_lib
+    d----    20.11.2015    19:06        <DIR> xilinx-ise
+    d----    20.11.2015    19:40        <DIR> xilinx-vivado
     ```
 
 ### Selectable Options for the Bash Scripts:

--- a/libraries/vendors/compile-xilinx-ise.sh
+++ b/libraries/vendors/compile-xilinx-ise.sh
@@ -4,10 +4,10 @@
 # kate: tab-width 2; replace-tabs off; indent-width 2;
 # 
 # ==============================================================================
+#	Authors:						Patrick Lehmann
+# 
 #	Bash Script:				Script to compile the simulation libraries from Xilinx ISE
 #											for GHDL on Linux
-# 
-#	Authors:						Patrick Lehmann
 # 
 # Description:
 # ------------------------------------
@@ -16,7 +16,7 @@
 #		- compiles all Xilinx ISE simulation libraries and packages
 #
 # ==============================================================================
-#	Copyright (C) 2015 Patrick Lehmann
+#	Copyright (C) 2015-2016 Patrick Lehmann
 #	
 #	GHDL is free software; you can redistribute it and/or modify it under
 #	the terms of the GNU General Public License as published by the Free
@@ -38,68 +38,85 @@
 # save working directory
 WorkingDir=$(pwd)
 ScriptDir="$(dirname $0)"
-ScriptDir="$(realpath $ScriptDir)"
+ScriptDir="$(readlink -f $ScriptDir)"
 
 # source configuration file from GHDL's 'vendors' library directory
 source $ScriptDir/config.sh
 source $ScriptDir/shared.sh
 
-NO_COMMAND=TRUE
-
 # command line argument processing
+NO_COMMAND=1
+SKIP_EXISTING_FILES=0
+SKIP_LARGE_FILES=0
+SUPPRESS_WARNINGS=0
+HALT_ON_ERROR=0
+VHDLStandard=93
+GHDLBinDir=""
+DestDir=""
+SrcDir=""
 while [[ $# > 0 ]]; do
 	key="$1"
 	case $key in
 		-c|--clean)
 		CLEAN=TRUE
-		NO_COMMAND=FALSE
+		NO_COMMAND=0
 		;;
 		-a|--all)
-		ALL=TRUE
-		NO_COMMAND=FALSE
-		;;
-		-s|--skip-existing)
-		SKIP_EXISTING_FILES=TRUE
-		;;
-		-S|--skip-largefiles)
-		SKIP_LARGE_FILES=TRUE
-		;;
-		-n|--no-warnings)
-		SUPPRESS_WARNINGS=TRUE
-		;;
-		-H|--halt-on-error)
-		HALT_ON_ERROR=TRUE
-		;;
-#		-v|--verbose)
-#		VERBOSE=TRUE
-#		;;
-		-h|--help)
-		HELP=TRUE
-		NO_COMMAND=FALSE
+		COMPILE_ALL=TRUE
+		NO_COMMAND=0
 		;;
 		--unisim)
-		UNISIM=TRUE
-		NO_COMMAND=FALSE
+		COMPILE_UNISIM=TRUE
+		NO_COMMAND=0
 		;;
 		--unimacro)
-		UNIMACRO=TRUE
-		NO_COMMAND=FALSE
+		COMPILE_UNIMACRO=TRUE
+		NO_COMMAND=0
 		;;
 		--simprim)
-		SIMPRIM=TRUE
-		NO_COMMAND=FALSE
+		COMPILE_SIMPRIM=TRUE
+		NO_COMMAND=0
 		;;
 		--secureip)
-		SECUREIP=TRUE
+		COMPILE_SECUREIP=TRUE
+		;;
+		-h|--help)
+		HELP=TRUE
+		NO_COMMAND=0
+		;;
+		-s|--skip-existing)
+		SKIP_EXISTING_FILES=1
+		;;
+		-S|--skip-largefiles)
+		SKIP_LARGE_FILES=1
+		;;
+		-n|--no-warnings)
+		SUPPRESS_WARNINGS=1
+		;;
+		-H|--halt-on-error)
+		HALT_ON_ERROR=1
 		;;
 		--vhdl93)
-		VHDL93=TRUE
+		VHDLStandard=93
 		;;
 		--vhdl2008)
-		VHDL2008=TRUE
+		VHDLStandard=2008
+		;;
+		--ghdl)
+		GHDLBinDir="$2"
+		shift						# skip argument
+		;;
+		--src)
+		SrcDir="$2"
+		shift						# skip argument
+		;;
+		--out)
+		DestDir="$2"
+		shift						# skip argument
 		;;
 		*)		# unknown option
-		UNKNOWN_OPTION=TRUE
+		echo 1>&2 -e "${COLORED_ERROR} Unknown command line option.${ANSI_RESET}"
+		exit -1
 		;;
 	esac
 	shift # past argument or value
@@ -109,20 +126,16 @@ if [ "$NO_COMMAND" == "TRUE" ]; then
 	HELP=TRUE
 fi
 
-if [ "$UNKNOWN_OPTION" == "TRUE" ]; then
-	echo -e $COLORED_ERROR "Unknown command line option.${ANSI_RESET}"
-	exit -1
-elif [ "$HELP" == "TRUE" ]; then
-	if [ "$NO_COMMAND" == "TRUE" ]; then
-		echo -e $COLORED_ERROR " No command selected."
-	fi
+if [ "$HELP" == "TRUE" ]; then
+	test "$NO_COMMAND" == "TRUE" && echo 1>&2 -e "${COLORED_ERROR} No command selected."
 	echo ""
 	echo "Synopsis:"
-	echo "  Script to compile the simulation libraries from Xilinx ISE for GHDL on Linux"
+	echo "  A script to compile the Xilinx ISE simulation libraries for GHDL on Linux."
+	echo "  One library folder 'lib/v??' per VHDL library will be created relative to the current"
+	echo "  working directory."
 	echo ""
 	echo "Usage:"
-	echo "  compile-xilinx-ise.sh <common command>|<library> [<options>]"
-#         [-v] [-c] [--unisim] [--unimacro] [--simprim] [--secureip] [-s|--skip-existing] [-S|--skip-largefiles] [-n|--no-warnings]
+	echo "  compile-xilinx-ise.sh <common command>|<library> [<options>] [<adv. options>]"
 	echo ""
 	echo "Common commands:"
 	echo "  -h --help             Print this help page"
@@ -142,297 +155,170 @@ elif [ "$HELP" == "TRUE" ]; then
 	echo "  -S --skip-largefiles  Don't compile large entities like DSP and PCIe primitives."
 	echo "  -H --halt-on-error    Halt on error(s)."
 	echo ""
+	echo "Advanced options:"
+	echo "  --ghdl <GHDL BinDir>   Path to GHDL binary directory e.g. /usr/bin."
+	echo "  --out <dir name>       Name of the output directory."
+	echo "  --src <Path to OSVVM>  Name of the output directory."
+	echo ""
 	echo "Verbosity:"
-#	echo "  -v --verbose          Print more messages"
 	echo "  -n --no-warnings      Suppress all warnings. Show only error messages."
 	echo ""
 	exit 0
 fi
 
-if [ "$ALL" == "TRUE" ]; then
-	UNISIM=TRUE
-	UNIMACRO=TRUE
-	SIMPRIM=TRUE
-	SECUREIP=TRUE
+if [ "$COMPILE_ALL" == "TRUE" ]; then
+	COMPILE_UNISIM=TRUE
+	COMPILE_UNIMACRO=TRUE
+	COMPILE_SIMPRIM=TRUE
+	COMPILE_SECUREIP=TRUE
 fi
 
-if [ "$VHDL93" == "TRUE" ]; then
-	VHDLStandard="93c"
-	VHDLFlavor="synopsys"
-elif [ "$VHDL2008" == "TRUE" ]; then
-	VHDLStandard="08"
-	VHDLFlavor="standard"
+if [ $VHDLStandard -eq 2008 ]; then
 	echo -e "${ANSI_RED}Not all Xilinx primitives are VHDL-2008 compatible! Setting HALT_ON_ERROR to FALSE.${ANSI_RESET}"
 	HALT_ON_ERROR=FALSE
-else
-	VHDLStandard="93c"
-	VHDLFlavor="synopsys"
 fi
 
-# extract data from configuration
-SourceDir=${SourceDirectory[XilinxISE]}
-DestinationDir=${DestinationDirectory[XilinxISE]}
 
-if [ -z $DestinationDir ]; then
-	echo -e "${COLORED_ERROR} Xilinx ISE is not configured in '$ScriptDir/config.sh'${ANSI_RESET}"
-	exit -1
-elif [ ! -d $SourceDir ]; then
-	echo -e "${COLORED_ERROR} Path '$SourceDir' does not exist.${ANSI_RESET}"
-	exit -1
-fi
+# -> $SourceDirectories
+# -> $DestinationDirectories
+# -> $SrcDir
+# -> $DestDir
+# -> $GHDLBinDir
+# <= $SourceDirectory
+# <= $DestinationDirectory
+# <= $GHDLBinary
+SetupDirectories XilinxISE "Xilinx ISE"
 
-# set bash options
-set -o pipefail
+# create "xilinx-ise" directory and change to it
+# => $DestinationDirectory
+CreateDestinationDirectory
+cd $DestinationDirectory
+
+
+# => $SUPPRESS_WARNINGS
+# <= $GRC_COMMAND
+SetupGRCat
+
+
+# -> $VHDLStandard
+# <= $VHDLVersion
+# <= $VHDLStandard
+# <= $VHDLFlavor
+GHDLSetup
+
 
 # define global GHDL Options
 GHDL_OPTIONS=(-fexplicit -frelaxed-rules --no-vital-checks --warn-binding --mb-comments)
 
-# create "xilinx" directory and change to it
-if [[ -d "$DestinationDir" ]]; then
-	echo -e "${ANSI_YELLOW}Vendor directory '$DestinationDir' already exists.${ANSI_RESET}"
-else
-	echo -e "${ANSI_YELLOW}Creating vendor directory: '$DestinationDir'${ANSI_RESET}"
-	mkdir "$DestinationDir"
-fi
-cd $DestinationDir
 
-if [ -z "$(which grcat)" ]; then
-	# if grcat (generic colourizer) is not installed, use a dummy pipe command like 'cat'
-	GRC_COMMAND="cat"
-else
-	if [ "$SUPPRESS_WARNINGS" == "TRUE" ]; then
-		GRC_COMMAND="grcat $ScriptDir/ghdl.skipwarning.grcrules"
-	else
-		GRC_COMMAND="grcat $ScriptDir/ghdl.grcrules"
-	fi
-fi
+GHDL_PARAMS=(${GHDL_OPTIONS[@]})
+GHDL_PARAMS+=(--ieee=$VHDLFlavor --std=$VHDLStandard -P$DestinationDirectory)
 
-STOPCOMPILING=FALSE
+
+STOPCOMPILING=0
 ERRORCOUNT=0
 
 # Cleanup directory
 # ==============================================================================
 if [ "$CLEAN" == "TRUE" ]; then
+	echo 1>&2 -e "${COLORED_ERROR} '--clean' is not implemented!"
+	exit -1
 	echo -e "${ANSI_YELLOW}Cleaning up vendor directory ...${ANSI_RESET}"
 	rm *.o 2> /dev/null
+	rm *.cf 2> /dev/null
 fi
 
 # Library unisim
 # ==============================================================================
 # compile unisim packages
-if [ "$STOPCOMPILING" == "FALSE" ] && [ "$UNISIM" == "TRUE" ]; then
-	echo -e "${ANSI_YELLOW}Compiling library 'unisim' ...${ANSI_RESET}"
-	GHDL_PARAMS=(${GHDL_OPTIONS[@]})
-	GHDL_PARAMS+=(--ieee=$VHDLFlavor --std=$VHDLStandard)
+if [ $STOPCOMPILING -eq 0 ] && [ "$COMPILE_UNISIM" == "TRUE" ]; then
+	Library="unisim"
 	Files=(
-		$SourceDir/unisims/unisim_VPKG.vhd
-		$SourceDir/unisims/unisim_VCOMP.vhd
+		${Library}s/unisim_VPKG.vhd
+		${Library}s/unisim_VCOMP.vhd
 	)
+	# append absolute source path
+	SourceFiles=()
 	for File in ${Files[@]}; do
-		FileName=$(basename "$File")
-		if [ "$SKIP_EXISTING_FILES" == "TRUE" ] && [ -e "${FileName%.*}.o" ]; then
-			echo -e "${ANSI_CYAN}Skipping package '$File'${ANSI_RESET}"
-		else
-			echo -e "${ANSI_CYAN}Analyzing package '$File'${ANSI_RESET}"
-			ghdl -a ${GHDL_PARAMS[@]} --work=unisim "$File" 2>&1 | $GRC_COMMAND
-			if [ $? -ne 0 ]; then
-				let ERRORCOUNT++
-				if [ "$HALT_ON_ERROR" == "TRUE" ]; then
-					STOPCOMPILING=TRUE
-					break
-				fi
-			fi
-		fi
+		SourceFiles+=("$SourceDirectory/$File")
 	done
+
+	GHDLCompilePackages
 fi
 
 # compile unisim primitives
-if [ "$STOPCOMPILING" == "FALSE" ] && [ "$UNISIM" == "TRUE" ]; then
-	GHDL_PARAMS=(${GHDL_OPTIONS[@]})
-	GHDL_PARAMS+=(--ieee=$VHDLFlavor --std=$VHDLStandard)
-	Files="$(LC_COLLATE=C ls $SourceDir/unisims/primitive/*.vhd)"
-	for File in $Files; do
-		FileName=$(basename "$File")
-		FileSize=($(wc -c $File))
-		if [ "$SKIP_EXISTING_FILES" == "TRUE" ] && [ -e "${FileName%.*}.o" ]; then
-			echo -n ""
-#			echo -e "${ANSI_CYAN}Skipping package '$File'${ANSI_RESET}"
-		elif [ "$SKIP_LARGE_FILES" == "TRUE" ] && [ ${FileSize[0]} -gt $LARGE_FILESIZE ]; then
-			echo -e "${ANSI_CYAN}Skipping large '$File'${ANSI_RESET}"
-		else
-			echo -e "${ANSI_CYAN}Analyzing primitive '$File'${ANSI_RESET}"
-			ghdl -a ${GHDL_PARAMS[@]} --work=unisim "$File" 2>&1 | $GRC_COMMAND
-			if [ $? -ne 0 ]; then
-				let ERRORCOUNT++
-				if [ "$HALT_ON_ERROR" == "TRUE" ]; then
-					STOPCOMPILING=TRUE
-					break
-				fi
-			fi
-		fi
-	done
+if [ $STOPCOMPILING -eq 0 ] && [ "$COMPILE_UNISIM" == "TRUE" ]; then
+	Library="unisim"
+	SourceFiles="$(LC_COLLATE=C ls $SourceDirectory/${Library}s/primitive/*.vhd)"
+
+	GHDLCompileLibrary
 fi
 
 # compile unisim secureip primitives
-if [ "$STOPCOMPILING" == "FALSE" ] && [ "$UNISIM" == "TRUE" ] && [ "$SECUREIP" == "TRUE" ]; then
-	echo -e "${ANSI_YELLOW}Compiling library secureip primitives${ANSI_RESET}"
-	GHDL_PARAMS=(${GHDL_OPTIONS[@]})
-	GHDL_PARAMS+=(--ieee=$VHDLFlavor --std=$VHDLStandard)
-	Files="$(LC_COLLATE=C ls $SourceDir/unisims/secureip/*.vhd)"
-	for File in $Files; do
-		FileName=$(basename "$File")
-		FileSize=($(wc -c $File))
-		if [ "$SKIP_EXISTING_FILES" == "TRUE" ] && [ -e "${FileName%.*}.o" ]; then
-			echo -n ""
-#			echo -e "${ANSI_CYAN}Skipping package '$File'${ANSI_RESET}"
-		elif [ "$SKIP_LARGE_FILES" == "TRUE" ] && [ ${FileSize[0]} -gt $LARGE_FILESIZE ]; then
-			echo -e "${ANSI_CYAN}Skipping large '$File'${ANSI_RESET}"
-		else
-			echo -e "${ANSI_CYAN}Analyzing primitive '$File'${ANSI_RESET}"
-			ghdl -a ${GHDL_PARAMS[@]} --work=secureip "$File" 2>&1 | $GRC_COMMAND
-			if [ $? -ne 0 ]; then
-				let ERRORCOUNT++
-				if [ "$HALT_ON_ERROR" == "TRUE" ]; then
-					STOPCOMPILING=TRUE
-					break
-				fi
-			fi
-		fi
-	done
+if [ $STOPCOMPILING -eq 0 ] && [ "$COMPILE_UNISIM" == "TRUE" ] && [ "$COMPILE_SECUREIP" == "TRUE" ]; then
+	Library="secureip"
+	SourceFiles="$(LC_COLLATE=C ls $SourceDirectory/unisims/$Library/*.vhd)"
+
+	GHDLCompileLibrary
 fi
 
 # Library unimacro
 # ==============================================================================
 # compile unimacro packages
-if [ "$STOPCOMPILING" == "FALSE" ] && [ "$UNIMACRO" == "TRUE" ]; then
-	echo -e "${ANSI_YELLOW}Compiling library 'unimacro' ...${ANSI_RESET}"
-	GHDL_PARAMS=(${GHDL_OPTIONS[@]})
-	GHDL_PARAMS+=(--ieee=$VHDLFlavor --std=$VHDLStandard)
+if [ $STOPCOMPILING -eq 0 ] && [ "$COMPILE_UNIMACRO" == "TRUE" ]; then
+	Library="unimacro"
 	Files=(
-		$SourceDir/unimacro/unimacro_VCOMP.vhd
+		$Library/unimacro_VCOMP.vhd
 	)
+	# append absolute source path
+	SourceFiles=()
 	for File in ${Files[@]}; do
-		FileName=$(basename "$File")
-		if [ "$SKIP_EXISTING_FILES" == "TRUE" ] && [ -e "${FileName%.*}.o" ]; then
-			echo -e "${ANSI_CYAN}Skipping package '$File'${ANSI_RESET}"
-		else
-			echo -e "${ANSI_CYAN}Analyzing package '$File'${ANSI_RESET}"
-			ghdl -a ${GHDL_PARAMS[@]} --work=unimacro "$File" 2>&1 | $GRC_COMMAND
-			if [ $? -ne 0 ]; then
-				let ERRORCOUNT++
-				if [ "$HALT_ON_ERROR" == "TRUE" ]; then
-					STOPCOMPILING=TRUE
-					break
-				fi
-			fi
-		fi
+		SourceFiles+=("$SourceDirectory/$File")
 	done
+
+	GHDLCompilePackages
 fi
 	
 # compile unimacro macros
-if [ "$STOPCOMPILING" == "FALSE" ] && [ "$UNIMACRO" == "TRUE" ]; then
-	GHDL_PARAMS=(${GHDL_OPTIONS[@]})
-	GHDL_PARAMS+=(--ieee=$VHDLFlavor --std=$VHDLStandard)
-	Files="$(LC_COLLATE=C ls $SourceDir/unimacro/*_MACRO.vhd)"
-	for File in $Files; do
-		FileName=$(basename "$File")
-		if [ "$SKIP_EXISTING_FILES" == "TRUE" ] && [ -e "${FileName%.*}.o" ]; then
-			echo -e "${ANSI_CYAN}Skipping package '$File'${ANSI_RESET}"
-		else
-			echo -e "${ANSI_CYAN}Analyzing primitive '$File'${ANSI_RESET}"
-			ghdl -a ${GHDL_PARAMS[@]} --work=unimacro "$File" 2>&1 | $GRC_COMMAND
-			if [ $? -ne 0 ]; then
-				let ERRORCOUNT++
-				if [ "$HALT_ON_ERROR" == "TRUE" ]; then
-					STOPCOMPILING=TRUE
-					break
-				fi
-			fi
-		fi
-	done
+if [ $STOPCOMPILING -eq 0 ] && [ "$COMPILE_UNIMACRO" == "TRUE" ]; then
+	Library="unimacro"
+	SourceFiles="$(LC_COLLATE=C ls $SourceDirectory/$Library/*_MACRO.vhd)"
+
+	GHDLCompileLibrary
 fi
 
 # Library simprim
 # ==============================================================================
 # compile simprim packages
-if [ "$STOPCOMPILING" == "FALSE" ] && [ "$SIMPRIM" == "TRUE" ]; then
-	echo -e "${ANSI_YELLOW}Compiling library 'simprim' ...${ANSI_RESET}"
-	GHDL_PARAMS=(${GHDL_OPTIONS[@]})
-	GHDL_PARAMS+=(--ieee=$VHDLFlavor --std=$VHDLStandard)
+if [ $STOPCOMPILING -eq 0 ] && [ "$COMPILE_SIMPRIM" == "TRUE" ]; then
+	Library="simprim"
 	Files=(
-		$SourceDir/simprims/simprim_Vpackage.vhd
-		$SourceDir/simprims/simprim_Vcomponents.vhd
+		${Library}s/simprim_Vpackage.vhd
+		${Library}s/simprim_Vcomponents.vhd
 	)
+	# append absolute source path
+	SourceFiles=()
 	for File in ${Files[@]}; do
-		FileName=$(basename "$File")
-		if [ "$SKIP_EXISTING_FILES" == "TRUE" ] && [ -e "${FileName%.*}.o" ]; then
-			echo -e "${ANSI_CYAN}Skipping package '$File'${ANSI_RESET}"
-		else
-			echo -e "${ANSI_CYAN}Analyzing package '$File'${ANSI_RESET}"
-			ghdl -a ${GHDL_PARAMS[@]} --work=simprim "$File" 2>&1 | $GRC_COMMAND
-			if [ $? -ne 0 ]; then
-				let ERRORCOUNT++
-				if [ "$HALT_ON_ERROR" == "TRUE" ]; then
-					STOPCOMPILING=TRUE
-					break
-				fi
-			fi
-		fi
+		SourceFiles+=("$SourceDirectory/$File")
 	done
+
+	GHDLCompilePackages
 fi
 
 # compile simprim primitives
-if [ "$STOPCOMPILING" == "FALSE" ] && [ "$SIMPRIM" == "TRUE" ]; then
-	GHDL_PARAMS=(${GHDL_OPTIONS[@]})
-	GHDL_PARAMS+=(--ieee=$VHDLFlavor --std=$VHDLStandard)
-	Files="$(LC_COLLATE=C ls $SourceDir/simprims/primitive/other/*.vhd)"
-	for File in $Files; do
-		FileName=$(basename "$File")
-		FileSize=($(wc -c $File))
-		if [ "$SKIP_EXISTING_FILES" == "TRUE" ] && [ -e "${FileName%.*}.o" ]; then
-			echo -n ""
-#			echo -e "${ANSI_CYAN}Skipping package '$File'${ANSI_RESET}"
-		elif [ "$SKIP_LARGE_FILES" == "TRUE" ] && [ ${FileSize[0]} -gt $LARGE_FILESIZE ]; then
-			echo -e "${ANSI_CYAN}Skipping large '$File'${ANSI_RESET}"
-		else
-			echo -e "${ANSI_CYAN}Analyzing primitive '$File'${ANSI_RESET}"
-			ghdl -a ${GHDL_PARAMS[@]} --work=simprim "$File" 2>&1 | $GRC_COMMAND
-			if [ $? -ne 0 ]; then
-				let ERRORCOUNT++
-				if [ "$HALT_ON_ERROR" == "TRUE" ]; then
-					STOPCOMPILING=TRUE
-					break
-				fi
-			fi
-		fi
-	done
+if [ $STOPCOMPILING -eq 0 ] && [ "$COMPILE_SIMPRIM" == "TRUE" ]; then
+	Library="simprim"
+	SourceFiles="$(LC_COLLATE=C ls $SourceDirectory/${Library}s/primitive/other/*.vhd)"
+
+	GHDLCompileLibrary
 fi
 
 # compile simprim secureip primitives
-if [ "$STOPCOMPILING" == "FALSE" ] && [ "$SIMPRIM" == "TRUE" ] && [ "$SECUREIP" == "TRUE" ]; then
-	GHDL_PARAMS=(${GHDL_OPTIONS[@]})
-	GHDL_PARAMS+=(--ieee=$VHDLFlavor --std=$VHDLStandard)
-	Files="$(LC_COLLATE=C ls $SourceDir/simprims/secureip/other/*.vhd)"
-	for File in $Files; do
-		FileName=$(basename "$File")
-		FileSize=($(wc -c $File))
-		if [ "$SKIP_EXISTING_FILES" == "TRUE" ] && [ -e "${FileName%.*}.o" ]; then
-			echo -n ""
-#			echo -e "${ANSI_CYAN}Skipping package '$File'${ANSI_RESET}"
-		elif [ "$SKIP_LARGE_FILES" == "TRUE" ] && [ ${FileSize[0]} -gt $LARGE_FILESIZE ]; then
-			echo -e "${ANSI_CYAN}Skipping large '$File'${ANSI_RESET}"
-		else
-			echo -e "${ANSI_CYAN}Analyzing primitive '$File'${ANSI_RESET}"
-			ghdl -a ${GHDL_PARAMS[@]} --work=simprim "$File" 2>&1 | $GRC_COMMAND
-			if [ $? -ne 0 ]; then
-				let ERRORCOUNT++
-				if [ "$HALT_ON_ERROR" == "TRUE" ]; then
-					STOPCOMPILING=TRUE
-					break
-				fi
-			fi
-		fi
-	done
+if [ $STOPCOMPILING -eq 0 ] && [ "$COMPILE_SIMPRIM" == "TRUE" ] && [ "$COMPILE_SECUREIP" == "TRUE" ]; then
+	Library="secureip"
+	SourceFiles="$(LC_COLLATE=C ls $SourceDirectory/simprims/$Library/other/*.vhd)"
+
+	GHDLCompileLibrary
 fi
 	
 echo "--------------------------------------------------------------------------------"
@@ -442,5 +328,3 @@ if [ $ERRORCOUNT -gt 0 ]; then
 else
 	echo -e $COLORED_SUCCESSFUL
 fi
-
-cd $WorkingDir

--- a/libraries/vendors/config.sh
+++ b/libraries/vendors/config.sh
@@ -39,31 +39,31 @@
 # 
 # These values are used if no command line argument (--src) is passed to a
 # compile script. Empty strings means not configured.
-declare -A InstallationDirectory
-InstallationDirectory[AlteraQuartus]="/opt/Altera/15.1"
-InstallationDirectory[XilinxISE]="/opt/Xilinx/14.7"
-InstallationDirectory[XilinxVivado]="/opt/Xilinx/Vivado/2016.1"
-InstallationDirectory[LatticeDiamond]="/usr/local/diamond/3.7_x64"
-InstallationDirectory[OSVVM]="/home/paebbels/git/PoC/lib/osvvm"
-InstallationDirectory[VUnit]="/home/paebbels/git/PoC/lib/vunit"
+declare -A InstallationDirectories
+InstallationDirectories[AlteraQuartus]="/opt/altera/16.0"
+InstallationDirectories[XilinxISE]="/opt/Xilinx/14.7"
+InstallationDirectories[XilinxVivado]="/opt/Xilinx/Vivado/2016.2"
+InstallationDirectories[LatticeDiamond]="/usr/local/diamond/3.7_x64"
+InstallationDirectories[OSVVM]="/home/paebbels/git/PoC/lib/osvvm"
+InstallationDirectories[VUnit]="/home/paebbels/git/PoC/lib/vunit"
 
 # Configure preferred output directories for each library set:
-declare -A DestinationDirectory
-DestinationDirectory[AlteraQuartus]="altera"
-DestinationDirectory[XilinxISE]="xilinx-ise"
-DestinationDirectory[XilinxVivado]="xilinx-vivado"
-DestinationDirectory[LatticeDiamond]="lattice"
-DestinationDirectory[OSVVM]="osvvm"
-DestinationDirectory[VUnit]="vuint"
+declare -A DestinationDirectories
+DestinationDirectories[AlteraQuartus]="altera"
+DestinationDirectories[XilinxISE]="xilinx-ise"
+DestinationDirectories[XilinxVivado]="xilinx-vivado"
+DestinationDirectories[LatticeDiamond]="lattice"
+DestinationDirectories[OSVVM]="."		# "osvvm"
+DestinationDirectories[VUnit]="."		# "vunit_lib"
 
 # Declare source directories depending on the installation paths:
-declare -A SourceDirectory
-SourceDirectory[AlteraQuartus]="${InstallationDirectory[AlteraQuartus]}/quartus/eda/sim_lib"
-SourceDirectory[XilinxISE]="${InstallationDirectory[XilinxISE]}/ISE_DS/ISE/vhdl/src"
-SourceDirectory[XilinxVivado]="${InstallationDirectory[XilinxVivado]}/data/vhdl/src"
-SourceDirectory[LatticeDiamond]="${InstallationDirectory[LatticeDiamond]}/cae_library/simulation/vhdl"
-SourceDirectory[OSVVM]="${InstallationDirectory[OSVVM]}"
-SourceDirectory[VUnit]="${InstallationDirectory[VUnit]}/vunit/vhdl"
+declare -A SourceDirectories
+SourceDirectories[AlteraQuartus]="${InstallationDirectories[AlteraQuartus]}/quartus/eda/sim_lib"
+SourceDirectories[XilinxISE]="${InstallationDirectories[XilinxISE]}/ISE_DS/ISE/vhdl/src"
+SourceDirectories[XilinxVivado]="${InstallationDirectories[XilinxVivado]}/data/vhdl/src"
+SourceDirectories[LatticeDiamond]="${InstallationDirectories[LatticeDiamond]}/cae_library/simulation/vhdl"
+SourceDirectories[OSVVM]="${InstallationDirectories[OSVVM]}"
+SourceDirectories[VUnit]="${InstallationDirectories[VUnit]}/vunit/vhdl"
 
 # input files greater than $LARGE_FILESIZE are skipped if '--skip-largefiles' is set
 LARGE_FILESIZE=125000


### PR DESCRIPTION
Hello,
here is the next part of reworked vendor library compile scripts.

New features:
- Partial VHDL-2008 support for Xilinx ISE and Vivado libraries.
- Refectored reusable code into Bash functions.
- Generate GHDL outputs into the new directory structure -> lib/v93 / lib/v08 (See #69)
- Replaced `realpath` (Debian specific) with `readlink -f` (tested e.g. on Ubuntu).
- Added new CLI parameters:
  - `--src` -> source folder
  - `--out` -> output folder
  - `--ghdl` -> ghdl binary directory

TODO:
- Use environment variables like `XILINX` to auto-detect the Xilinx installation directory.
- Search vendor libraries in default installation directories, e.g. in `/opt/...`.
- Translate all Bash-Script improvements back to PowerShell.

@cclassic Please check, if the changes made for Lattice Diamond still work on you machine. I have tested it in my virtual machine with Diamond 3.7 x86-64 on Debian. The script creates the new directory structure introduced in #69.

P.S.
This is a fresh branch, let's see how GitHub merges work...