### PR TITLE
Compile scripts: Implemented a default installation directory guessing

### DIFF
--- a/libraries/vendors/README.md
+++ b/libraries/vendors/README.md
@@ -10,7 +10,7 @@ and [VUnit][vunit], which can be pre-compile.
 
 The compilation scripts are writen in shell languages: PowerShell for Windows
 and Bash for Linux. The compile scripts can colorize the GHDL warning and error
-lines with the help of grc ([generic colourizer][grc]).
+lines with the help of grc/grcat ([generic colourizer][grc]).
 
  [osvvm]: http://osvvm.org/
  [vunit]: https://github.com/LarsAsplund/vunit
@@ -18,7 +18,7 @@ lines with the help of grc ([generic colourizer][grc]).
 
 ##### Supported Vendors Libraries
 
- - Altera Quartus (13.x):
+ - Altera Quartus (&ge;13.0):
      - lpm, sgate
      - altera, altera_mf, altera_lnsim
      - arriaii, arriaii_pcie_hip, arriaiigz
@@ -29,11 +29,18 @@ lines with the help of grc ([generic colourizer][grc]).
      - stratixiv, stratixiv_pcie_hip
      - stratixv, stratixv_pcie_hip
      - fiftyfivenm, twentynm
- - Xilinx ISE (14.7):
+ - Lattice (&ge;3.6):
+     - ec
+     - ecp, ecp2, ecp3, ecp5u
+     - lptm, lptm2
+     - machxo, machxo2, machxo3l
+     - sc, scm
+     - xp, xp2
+ - Xilinx ISE (&ge;14.0):
      - unisim (incl. secureip)
      - unimacro
      - simprim (incl. secureip)
- - Xilinx Vivado (2015.x):
+ - Xilinx Vivado (&ge;2014.1):
      - unisim (incl. secureip)
      - unimacro
 

--- a/libraries/vendors/compile-altera.sh
+++ b/libraries/vendors/compile-altera.sh
@@ -47,6 +47,7 @@ source $ScriptDir/shared.sh
 # command line argument processing
 NO_COMMAND=1
 SKIP_EXISTING_FILES=0
+SKIP_LARGE_FILES=0
 SUPPRESS_WARNINGS=0
 HALT_ON_ERROR=0
 VHDLStandard=93
@@ -134,12 +135,12 @@ while [[ $# > 0 ]]; do
 	shift # past argument or value
 done
 
-if [ "$NO_COMMAND" == "TRUE" ]; then
+if [ $NO_COMMAND -eq 1 ]; then
 	HELP=TRUE
 fi
 
 if [ "$HELP" == "TRUE" ]; then
-	test "$NO_COMMAND" == "TRUE" && echo 1>&2 -e "${COLORED_ERROR} No command selected."
+	test $NO_COMMAND -eq 1 && echo 1>&2 -e "\n${COLORED_ERROR} No command selected."
 	echo ""
 	echo "Synopsis:"
 	echo "  A script to compile the Altera Quartus simulation libraries for GHDL on Linux."
@@ -170,9 +171,9 @@ if [ "$HELP" == "TRUE" ]; then
 	echo "  -H --halt-on-error     Halt on error(s)."
 	echo ""
 	echo "Advanced options:"
-	echo "  --ghdl <GHDL BinDir>   Path to GHDL binary directory e.g. /usr/bin."
+	echo "  --ghdl <GHDL Binary>   Path to GHDL's binary e.g. /usr/local/bin/ghdl."
 	echo "  --out <dir name>       Name of the output directory."
-	echo "  --src <Path to OSVVM>  Name of the output directory."
+	echo "  --src <Path to OSVVM>  Path to the source directory."
 	echo ""
 	echo "Verbosity:"
 	echo "  -n --no-warnings       Suppress all warnings. Show only error messages."
@@ -189,6 +190,22 @@ if [ "$COMPILE_ALL" == "TRUE" ]; then
 	COMPILE_NM=TRUE
 fi
 
+DefaultDirectories=("/opt/Altera" "/opt/altera")
+if [ ! -z $QUARTUS_ROOTDIR ]; then
+	EnvSourceDir=$QUARTUS_ROOTDIR/${SourceDirectories[AlteraQuartus]}
+else
+	for DefaultDir in ${DefaultDirectories[@]}; do
+		for Major in 17 16 15 14 13; do
+			for Minor in 3 2 1 0; do
+				Dir=$DefaultDir/${Major}.${Minor}/quartus
+				if [ -d $Dir ]; then
+					EnvSourceDir=$Dir/${SourceDirectories[AlteraQuartus]}
+					break 3
+				fi
+			done
+		done
+	done
+fi
 
 # -> $SourceDirectories
 # -> $DestinationDirectories

--- a/libraries/vendors/compile-osvvm.sh
+++ b/libraries/vendors/compile-osvvm.sh
@@ -98,12 +98,12 @@ done
 # makes no sense to enable it for OSVVM
 SKIP_EXISTING_FILES=0
 
-if [ "$NO_COMMAND" == "TRUE" ]; then
+if [ $NO_COMMAND -eq 1 ]; then
 	HELP=TRUE
 fi
 
 if [ "$HELP" == "TRUE" ]; then
-	test "$NO_COMMAND" == "TRUE" && echo 1>&2 -e "${COLORED_ERROR} No command selected."
+	test $NO_COMMAND -eq 1 && echo 1>&2 -e "\n${COLORED_ERROR} No command selected."
 	echo ""
 	echo "Synopsis:"
 	echo "  A script to compile the simulation library 'OSVVM' for GHDL on Linux."
@@ -127,9 +127,9 @@ if [ "$HELP" == "TRUE" ]; then
 	echo "  -H --halt-on-error     Halt on error(s)."
 	echo ""
 	echo "Advanced options:"
-	echo "  --ghdl <GHDL BinDir>   Path to GHDL binary directory e.g. /usr/bin."
+	echo "  --ghdl <GHDL Binary>   Path to GHDL's binary e.g. /usr/local/bin/ghdl."
 	echo "  --out <dir name>       Name of the output directory."
-	echo "  --src <Path to OSVVM>  Name of the output directory."
+	echo "  --src <Path to OSVVM>  Path to the source directory."
 	echo ""
 	echo "Verbosity:"
 	echo "  -n --no-warnings      Suppress all warnings. Show only error messages."

--- a/libraries/vendors/compile-vunit.sh
+++ b/libraries/vendors/compile-vunit.sh
@@ -98,12 +98,12 @@ done
 # makes no sense to enable it for VUnit
 SKIP_EXISTING_FILES=0
 
-if [ "$NO_COMMAND" == "TRUE" ]; then
+if [ $NO_COMMAND -eq 1 ]; then
 	HELP=TRUE
 fi
 
 if [ "$HELP" == "TRUE" ]; then
-	test "$NO_COMMAND" == "TRUE" && echo 1>&2 -e "${COLORED_ERROR} No command selected."
+	test $NO_COMMAND -eq 1 && echo 1>&2 -e "\n${COLORED_ERROR} No command selected."
 	echo ""
 	echo "Synopsis:"
 	echo "  A script to compile the simulation library 'vunit_lib' for GHDL on Linux."
@@ -125,9 +125,9 @@ if [ "$HELP" == "TRUE" ]; then
 	echo "  -H --halt-on-error    Halt on error(s)."
 	echo ""
 	echo "Advanced options:"
-	echo "  --ghdl <GHDL BinDir>   Path to GHDL binary directory e.g. /usr/bin."
+	echo "  --ghdl <GHDL Binary>   Path to GHDL's binary e.g. /usr/local/bin/ghdl."
 	echo "  --out <dir name>       Name of the output directory."
-	echo "  --src <Path to OSVVM>  Name of the output directory."
+	echo "  --src <Path to OSVVM>  Path to the source directory."
 	echo ""
 	echo "Verbosity:"
 	echo "  -n --no-warnings      Suppress all warnings. Show only error messages."

--- a/libraries/vendors/compile-xilinx-vivado.sh
+++ b/libraries/vendors/compile-xilinx-vivado.sh
@@ -63,7 +63,7 @@ while [[ $# > 0 ]]; do
 		;;
 		-a|--all)
 		COMPILE_ALL=TRUE
-		NO_COMMAND=FALSE
+		NO_COMMAND=0
 		;;
 		--unisim)
 		COMPILE_UNISIM=TRUE
@@ -118,12 +118,12 @@ while [[ $# > 0 ]]; do
 	shift # past argument or value
 done
 
-if [ "$NO_COMMAND" == "TRUE" ]; then
+if [ $NO_COMMAND -eq 1 ]; then
 	HELP=TRUE
 fi
 
 if [ "$HELP" == "TRUE" ]; then
-	test "$NO_COMMAND" == "TRUE" && echo 1>&2 -e "${COLORED_ERROR} No command selected."
+	test $NO_COMMAND -eq 1 && echo 1>&2 -e "\n${COLORED_ERROR} No command selected."
 	echo ""
 	echo "Synopsis:"
 	echo "  A script to compile the Xilinx Vivado simulation libraries for GHDL on Linux."
@@ -151,9 +151,9 @@ if [ "$HELP" == "TRUE" ]; then
 	echo "  -H --halt-on-error    Halt on error(s)."
 	echo ""
 	echo "Advanced options:"
-	echo "  --ghdl <GHDL BinDir>   Path to GHDL binary directory e.g. /usr/bin."
+	echo "  --ghdl <GHDL Binary>   Path to GHDL's binary e.g. /usr/local/bin/ghdl."
 	echo "  --out <dir name>       Name of the output directory."
-	echo "  --src <Path to OSVVM>  Name of the output directory."
+	echo "  --src <Path to OSVVM>  Path to the source directory."
 	echo ""
 	echo "Verbosity:"
 	echo "  -n --no-warnings      Suppress all warnings. Show only error messages."
@@ -169,13 +169,31 @@ fi
 
 if [ $VHDLStandard -eq 2008 ]; then
 	echo -e "${ANSI_RED}Not all Xilinx primitives are VHDL-2008 compatible! Setting HALT_ON_ERROR to FALSE.${ANSI_RESET}"
-	HALT_ON_ERROR=FALSE
+	HALT_ON_ERROR=0
 fi
 
+
+DefaultDirectories=("/opt/Xilinx/Vivado" "/opt/xilinx/Vivado")
+if [ ! -z $XILINX_VIVADO ]; then
+	EnvSourceDir=$XILINX_VIVADO/vhdl/src
+else
+	for DefaultDir in ${DefaultDirectories[@]}; do
+		for Major in 2017 2016 2015 2014; do
+			for Minor in 4 3 2 1; do
+				Dir=$DefaultDir/${Major}.${Minor}
+				if [ -d $Dir ]; then
+					EnvSourceDir=$Dir/${SourceDirectories[XilinxVivado]}
+					break 3
+				fi
+			done
+		done
+	done
+fi
 
 # -> $SourceDirectories
 # -> $DestinationDirectories
 # -> $SrcDir
+# -> $EnvSourceDir
 # -> $DestDir
 # -> $GHDLBinDir
 # <= $SourceDirectory
@@ -200,10 +218,8 @@ SetupGRCat
 # <= $VHDLFlavor
 GHDLSetup
 
-
 # define global GHDL Options
 GHDL_OPTIONS=(-fexplicit -frelaxed-rules --no-vital-checks --warn-binding --mb-comments)
-
 
 GHDL_PARAMS=(${GHDL_OPTIONS[@]})
 GHDL_PARAMS+=(--ieee=$VHDLFlavor --std=$VHDLStandard -P$DestinationDirectory)

--- a/libraries/vendors/config.sh
+++ b/libraries/vendors/config.sh
@@ -40,12 +40,12 @@
 # These values are used if no command line argument (--src) is passed to a
 # compile script. Empty strings means not configured.
 declare -A InstallationDirectories
-InstallationDirectories[AlteraQuartus]="/opt/altera/16.0"
-InstallationDirectories[XilinxISE]="/opt/Xilinx/14.7"
-InstallationDirectories[XilinxVivado]="/opt/Xilinx/Vivado/2016.2"
-InstallationDirectories[LatticeDiamond]="/usr/local/diamond/3.7_x64"
-InstallationDirectories[OSVVM]="/home/paebbels/git/PoC/lib/osvvm"
-InstallationDirectories[VUnit]="/home/paebbels/git/PoC/lib/vunit"
+InstallationDirectories[AlteraQuartus]=""     # "/opt/altera/16.0/quartus"
+InstallationDirectories[XilinxISE]=""	      # "/opt/Xilinx/14.7/ISE_DS/ISE"
+InstallationDirectories[XilinxVivado]=""      # "/opt/Xilinx/Vivado/2016.2"
+InstallationDirectories[LatticeDiamond]=""    # "/usr/local/diamond/3.7_x64"
+InstallationDirectories[OSVVM]=""	      # "~/git/github/osvvm"
+InstallationDirectories[VUnit]=""	      # "~/git/github/vunit"
 
 # Configure preferred output directories for each library set:
 declare -A DestinationDirectories
@@ -58,12 +58,12 @@ DestinationDirectories[VUnit]="."		# "vunit_lib"
 
 # Declare source directories depending on the installation paths:
 declare -A SourceDirectories
-SourceDirectories[AlteraQuartus]="${InstallationDirectories[AlteraQuartus]}/quartus/eda/sim_lib"
-SourceDirectories[XilinxISE]="${InstallationDirectories[XilinxISE]}/ISE_DS/ISE/vhdl/src"
-SourceDirectories[XilinxVivado]="${InstallationDirectories[XilinxVivado]}/data/vhdl/src"
-SourceDirectories[LatticeDiamond]="${InstallationDirectories[LatticeDiamond]}/cae_library/simulation/vhdl"
-SourceDirectories[OSVVM]="${InstallationDirectories[OSVVM]}"
-SourceDirectories[VUnit]="${InstallationDirectories[VUnit]}/vunit/vhdl"
+SourceDirectories[AlteraQuartus]="eda/sim_lib"
+SourceDirectories[XilinxISE]="vhdl/src"
+SourceDirectories[XilinxVivado]="data/vhdl/src"
+SourceDirectories[LatticeDiamond]="cae_library/simulation/vhdl"
+SourceDirectories[OSVVM]="."
+SourceDirectories[VUnit]="vunit/vhdl"
 
 # input files greater than $LARGE_FILESIZE are skipped if '--skip-largefiles' is set
 LARGE_FILESIZE=125000


### PR DESCRIPTION
Hello Tristan,

please merge this already squashed commit as a normal merge. Let's see what happens to the Git tree and merge history ... :).

Changes:
- Fixed minor issues (see #85), so Markus can test it again.
- Some scripts test for existing environment variables of vendor tools.
- Implemented a default installation directory guessing 'algorithm'.
- `--ghdl` refers to the GHDL executable not the binary directory.

Can you prepare an empty *.rst file (maybe with headline and a placeholder text),
where I could add the documentation for these scripts?

Regards
    Patrick