### PR TITLE
A first change set for MinGW32 and MinGW64

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -23,6 +23,8 @@ prefix=@prefix@
 backend=@backend@
 libdirsuffix=@libdirsuffix@
 libdirreverse=@libdirreverse@
+EXEEXT=@EXEEXT@
+LIBEXT=@LIBEXT@
 gcc_src_dir=@gcc_src_dir@
 LLVM_CONFIG=@llvm_config@
 LDFLAGS=@LDFLAGS@
@@ -211,8 +213,8 @@ libs.vhdl.llvmjit: ghdl_llvm_jit
 	$(MAKE) GHDL=ghdl_llvm_jit vhdl.libs.all
 
 libs.vhdl.llvm: ghdl_llvm ghdl1-llvm
-	$(MAKE) GHDL=ghdl_llvm ANALYZE_OPTS="--GHDL1=ghdl1-llvm" vhdl.libs.all
-	$(MAKE) GHDL1=./ghdl1-llvm libs.vhdl.standard
+	$(MAKE) GHDL=ghdl_llvm ANALYZE_OPTS="--GHDL1=ghdl1-llvm$(EXEEXT)" vhdl.libs.all
+	$(MAKE) GHDL1=./ghdl1-llvm$(EXEEXT) libs.vhdl.standard
 
 ghdl_llvm: force
 	$(GNATMAKE) $(GHDL_LLVM_INCFLAGS) -aI$(srcdir)/src/ghdldrv $(GNATFLAGS)\
@@ -236,8 +238,8 @@ install.grt.llvm: libgrt.a grt.lst install.dirs
 	$(INSTALL_DATA) $(GRTSRCDIR)/grt.ver $(DESTDIR)$(VHDL_LIB_DIR)/grt.ver
 
 install.llvm.program: install.dirs ghdl1-llvm ghdl_llvm
-	$(INSTALL_PROGRAM) ghdl_llvm $(DESTDIR)$(bindir)/ghdl
-	$(INSTALL_PROGRAM) ghdl1-llvm $(DESTDIR)$(bindir)/ghdl1-llvm
+	$(INSTALL_PROGRAM) ghdl_llvm$(EXEEXT) $(DESTDIR)$(bindir)/ghdl$(EXEEXT)
+	$(INSTALL_PROGRAM) ghdl1-llvm$(EXEEXT) $(DESTDIR)$(bindir)/ghdl1-llvm$(EXEEXT)
 
 install.llvm: install.llvm.program install.vhdllib install.grt.llvm
 
@@ -344,8 +346,8 @@ install.vhdllib: install.dirs
 
 clean: force
 	$(RM) -f *.o *.ali b~*.ad? *~ *.d b__*.ad? *.a *.deps *.bexch
-	$(RM) -f ghdl_gcc ghdl_mcode ghdl ghdl_llvm ghdl_llvm_jit ghdl_simul
-	$(RM) -f ghdl1-gcc ghdl1-llvm ghdl1-debug
+	$(RM) -f ghdl_gcc$(EXEEXT) ghdl_mcode$(EXEEXT) ghdl$(EXEEXT) ghdl_llvm$(EXEEXT) ghdl_llvm_jit$(EXEEXT) ghdl_simul$(EXEEXT)
+	$(RM) -f ghdl1-gcc$(EXEEXT) ghdl1-llvm$(EXEEXT) ghdl1-debug$(EXEEXT)
 	$(RM) -f run-bind.ad? grt.lst grt-files grt-files.in
 	$(RM) -rf lib
 

--- a/configure
+++ b/configure
@@ -17,11 +17,13 @@ llvm_config=
 backtrace_lib=
 build=
 build_mode=
+EXEEXT=
+LIBEXT=.so
 
 show_help=no
 progname=$0
 
-subst_vars="CC GNATMAKE CFLAGS LDFLAGS build srcdir prefix backend libdirsuffix libdirreverse gcc_src_dir llvm_config backtrace_lib build_mode"
+subst_vars="CC GNATMAKE CFLAGS LDFLAGS build srcdir prefix backend libdirsuffix libdirreverse gcc_src_dir llvm_config backtrace_lib build_mode EXEEXT LIBEXT"
 
 # Find srcdir
 srcdir=`dirname $progname`
@@ -169,6 +171,12 @@ if test $backend = llvm; then
     esac
 fi
 
+# Define default file extensions for Windows or Linux-like systems
+case "$build" in
+  *mingw*) LIBEXT=".dll"; EXEEXT=".exe";;
+  *)       LIBEXT=".so";  EXEEXT="";;
+esac
+
 # Generate config.status
 rm -f config.status
 {
@@ -211,7 +219,7 @@ fi
 if test $backend = mcode; then
     case "$build" in
 	*darwin*) ortho_flags="Flags_Macosx${mcode64}" ;;
-	*mingw32*) ortho_flags="Flags_Windows" ;;
+	*mingw32*) ortho_flags="Flags_Windows${mcode64}" ;;
 	*linux*) ortho_flags="Flags_Linux${mcode64}" ;;
 	*) echo "Unsupported $build build for mcode"; exit 1;;
     esac
@@ -230,10 +238,10 @@ fi
 # Generate default_pathes.ads
 echo "Generate default_pathes.ads"
 curdir=`pwd`
-sed -e "s%@COMPILER_GCC@%ghdl1-gcc%" \
-    -e "s%@COMPILER_DEBUG@%ghdl1-debug%" \
-    -e "s%@COMPILER_MCODE@%ghdl1-mcode%" \
-    -e "s%@COMPILER_LLVM@%bin/ghdl1-llvm%" \
+sed -e "s%@COMPILER_GCC@%ghdl1-gcc$EXEEXT%" \
+    -e "s%@COMPILER_DEBUG@%ghdl1-debug$EXEEXT%" \
+    -e "s%@COMPILER_MCODE@%ghdl1-mcode$EXEEXT%" \
+    -e "s%@COMPILER_LLVM@%bin/ghdl1-llvm$EXEEXT%" \
     -e "s%@POST_PROCESSOR@%oread-$backend%" \
     -e "s%@INSTALL_PREFIX@%$prefix%" \
     -e "s%@LIB_PREFIX@%$libdirsuffix%" \

--- a/src/grt/Makefile.inc
+++ b/src/grt/Makefile.inc
@@ -47,8 +47,9 @@ endif
 GRT_ELF_OPTS:=-Wl,--version-script=@/grt.ver -Wl,--export-dynamic
 
 # Set target files.
-ifeq ($(filter-out mingw32,$(osys)),)
-  GRT_TARGET_OBJS=jumps.o math.o clock.o
+ifeq ($(filter-out mingw32 mingw64,$(osys)),)
+  GRT_TARGET_OBJS=win32.o clock.o
+  GRT_EXTRA_LIB=-ldbghelp
 else
   GRT_TARGET_OBJS=jumps.o times.o
   ifeq ($(filter-out linux,$(osys)),)

--- a/src/grt/config/win32.c
+++ b/src/grt/config/win32.c
@@ -79,9 +79,9 @@ get_bt_from_context (struct backtrace_addrs *bt, CONTEXT *ctxt, int skip)
 
   frame.AddrPC.Offset = ctxt->Rip;
   frame.AddrPC.Mode = AddrModeFlat;
-  frame.AddrFrame.Offset = ctx->Rsp;
+  frame.AddrFrame.Offset = ctxt->Rsp;
   frame.AddrFrame.Mode = AddrModeFlat;
-  frame.AddrStack.Offset = ctx->Rsp;
+  frame.AddrStack.Offset = ctxt->Rsp;
   frame.AddrStack.Mode = AddrModeFlat;
 
 #else

--- a/src/ortho/mcode/ortho_code-x86-flags_windows64.ads
+++ b/src/ortho/mcode/ortho_code-x86-flags_windows64.ads
@@ -1,0 +1,34 @@
+--  X86 ABI flags.
+--  Copyright (C) 2006 Tristan Gingold
+--
+--  GHDL is free software; you can redistribute it and/or modify it under
+--  the terms of the GNU General Public License as published by the Free
+--  Software Foundation; either version 2, or (at your option) any later
+--  version.
+--
+--  GHDL is distributed in the hope that it will be useful, but WITHOUT ANY
+--  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+--  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+--  for more details.
+--
+--  You should have received a copy of the GNU General Public License
+--  along with GCC; see the file COPYING.  If not, write to the Free
+--  Software Foundation, 59 Temple Place - Suite 330, Boston, MA
+--  02111-1307, USA.
+with Interfaces; use Interfaces;
+
+package Ortho_Code.X86.Flags_Windows64 is
+   --  If true, OE_Alloca calls __chkstk (Windows), otherwise OE_Alloc
+   --  modifies ESP directly.
+   Flag_Alloca_Call : constant Boolean := True;
+
+   --  Prefered stack alignment.
+   --  Must be a power of 2.
+   Stack_Boundary : constant Unsigned_32 := 2 ** 3;
+
+   --  Alignment for double (64 bit float).
+   Mode_F64_Align : constant Natural := 3;
+
+   --  32 bits.
+   M64 : constant Boolean := False;
+end Ortho_Code.X86.Flags_Windows64;


### PR DESCRIPTION
Hello,

this PR contains a first change set for MinGW32 and MinGW64 to compile GHDL with mcode and llvm back-ends on Windows x86-64.

**Changes:**
- Introduced configure and make variables for file extensions: `EXEEXT` and `LIBEXT`
- Duplicated the ortho_flags file for Windows x86-64 and selected it in the Makefile
- Replaced `jumps.o` and `math.o` with `win32.o`
- Fixed typo in `win32.c`
- Added linker argument `-ldbghelp`

**This PR solves:**
- issue #102: sub-issue 1 and 2
- issue #104: sub-issue 1 and 2

**Unsolved issues:**
- issue #102: sub-issue 3 (unusual termination causing an Ada runtime message)
- issue #104: sub-issue 3 (false `-o` option passing to `ghdl1-llvm.exe`)
- issue #105: sub-issue 1 (unknown op-codes in mcode for MinGW64)

Regards
    Patrick