### PR TITLE
More changes for MinGWxx and LLVm backend

### DIFF
--- a/src/ghdldrv/ghdllocal.adb
+++ b/src/ghdldrv/ghdllocal.adb
@@ -572,7 +572,7 @@ package body Ghdllocal is
       for I in Filename'Range loop
          if Filename (I) = '.' then
             Last := I - 1;
-         elsif Remove_Dir and then Filename (I) = Directory_Separator then
+         elsif Remove_Dir and then Is_Directory_Separator (Filename (I)) then
             First := I + 1;
             Last := Filename'Last;
          end if;

--- a/src/grt/Makefile.inc
+++ b/src/grt/Makefile.inc
@@ -178,7 +178,7 @@ grt-files: run-bind.adb
 # Also remove -lgnat and its associated -L flags.  This appears to be required
 #  with GNAT GPL 2005.
 grt-files.in: grt-files
-	sed -e "\!^./!d" -e "/-shared/d" -e "/-static/d" -e "/-lgnat/d" \
+	sed -e "\!^.[/\\]!d" -e "/-shared/d" -e "/-static/d" -e "/-lgnat/d" \
 	  -e "\X-L/Xd" < $< > $@
 
 grt.lst: grt-files.in

--- a/src/ortho/mcode/ortho_code-x86-flags_windows64.ads
+++ b/src/ortho/mcode/ortho_code-x86-flags_windows64.ads
@@ -30,5 +30,5 @@ package Ortho_Code.X86.Flags_Windows64 is
    Mode_F64_Align : constant Natural := 3;
 
    --  32 bits.
-   M64 : constant Boolean := False;
+   M64 : constant Boolean := True;
 end Ortho_Code.X86.Flags_Windows64;


### PR DESCRIPTION
**The PR changes:**
- Fixed a directory separator check
  *It was already implemented, but not applied to all existing checks. Are there other source lines, which might be missed?*
- Extended the sed rule to clean up the `grt.lst` file. Now it also removes `*.o` files with `.\`.
- Fixed `Flags.M64` for Windows x86_64

**This PR solves:**
- issue #104: sub-issue 3 (false `-o` option passing to `ghdl1-llvm.exe`)
- issue #105: sub-issue 1 (unknown op-codes in mcode for MinGW64)

**Unsolved issues:**
- issue #102: sub-issue 3 (unusual termination causing an Ada runtime message)

**New issues:**
- issue #110: `ghdl.exe -r testbench` can not execute `testbench`, because the file extension `*.exe` is missing