### PR TITLE
Clean up links, repository-wide

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -7,7 +7,7 @@ New in 0.34 (XXXX-XX-XX)
 * Mode backend ported to x86_64
 * Support cocotb (https://github.com/potentialventures/cocotb)
 * Main repository is now on github: https://github.com/tgingold/ghdl
-* Docs available on rtd: http://ghdl.readthedocs.org/en/latest/
+* Docs available on rtd: https://ghdl.readthedocs.org/en/latest/
 * Speed improved.
 * New option --psl-report, to report status of psl assert and cover.
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ GHDL is free software.  See the file COPYING for copying permission.
 The manuals, and some of the runtime libraries, are under different
 terms; see the individual source files for details.
 
-Doc is available on http://ghdl.readthedocs.org/en/latest/index.html
+Doc is available on https://ghdl.readthedocs.org/en/latest/index.html
 
 ## Building GHDL (Short instructions)
 

--- a/dist/mcode/winbuild.ps1
+++ b/dist/mcode/winbuild.ps1
@@ -113,7 +113,7 @@ if ($PSCmdlet.MyInvocation.BoundParameters["Debug"].IsPresent) 		{	$Script_Enabl
 if ($PSCmdlet.MyInvocation.BoundParameters["Verbose"].IsPresent)	{	$Script_EnableVerbose =	$true	}
 
 # Author:	Ed Wilson
-# Source:	http://blogs.technet.com/b/heyscriptingguy/archive/2011/07/23/use-powershell-to-modify-your-environmental-path.aspx
+# Source:	https://blogs.technet.com/b/heyscriptingguy/archive/2011/07/23/use-powershell-to-modify-your-environmental-path.aspx
 function Add-Path
 	(	[parameter(Mandatory=$True,ValueFromPipeline=$True,Position=0)]
 		[string]$AddedFolder
@@ -141,7 +141,7 @@ function Add-Path
 	}
 
 # Author:	Ed Wilson
-# Source:	http://blogs.technet.com/b/heyscriptingguy/archive/2011/07/23/use-powershell-to-modify-your-environmental-path.aspx
+# Source:	https://blogs.technet.com/b/heyscriptingguy/archive/2011/07/23/use-powershell-to-modify-your-environmental-path.aspx
 function Remove-Path
 	(	[parameter(Mandatory=$True,ValueFromPipeline=$True,Position=0)]
 		[string]$RemovedFolder

--- a/libraries/ieee/README.ieee
+++ b/libraries/ieee/README.ieee
@@ -1,4 +1,4 @@
-http://standards.ieee.org/news/2013/ieee_1076_vhdl.html
+https://standards.ieee.org/news/2013/ieee_1076_vhdl.html
 
 MODIFICATION TO IEEE 1076™ LICENSING TERMS ALLOWS FOR OPEN USE OF VHDL STANDARD’S SUPPLEMENTAL MATERIAL
 
@@ -27,4 +27,4 @@ The IEEE Standards Association, a globally recognized standards-setting body wit
 About IEEE 
 IEEE, a large, global technical professional organization, is dedicated to advancing technology for the benefit of humanity. Through its highly cited publications, conferences, technology standards, and professional and educational activities, IEEE is the trusted voice on a wide variety of areas ranging from aerospace systems, computers and telecommunications to biomedical engineering, electric power and consumer electronics. Learn more at the IEEE Web site. external link
 
-- See more at: http://standards.ieee.org/news/2013/ieee_1076_vhdl.html#sthash.UFLcTc7E.dpuf
+- See more at: https://standards.ieee.org/news/2013/ieee_1076_vhdl.html#sthash.UFLcTc7E.dpuf

--- a/libraries/ieee2008/README.ieee
+++ b/libraries/ieee2008/README.ieee
@@ -1,4 +1,4 @@
-http://standards.ieee.org/news/2013/ieee_1076_vhdl.html
+https://standards.ieee.org/news/2013/ieee_1076_vhdl.html
 
 MODIFICATION TO IEEE 1076™ LICENSING TERMS ALLOWS FOR OPEN USE OF VHDL STANDARD’S SUPPLEMENTAL MATERIAL
 
@@ -27,4 +27,4 @@ The IEEE Standards Association, a globally recognized standards-setting body wit
 About IEEE 
 IEEE, a large, global technical professional organization, is dedicated to advancing technology for the benefit of humanity. Through its highly cited publications, conferences, technology standards, and professional and educational activities, IEEE is the trusted voice on a wide variety of areas ranging from aerospace systems, computers and telecommunications to biomedical engineering, electric power and consumer electronics. Learn more at the IEEE Web site. external link
 
-- See more at: http://standards.ieee.org/news/2013/ieee_1076_vhdl.html#sthash.UFLcTc7E.dpuf
+- See more at: https://standards.ieee.org/news/2013/ieee_1076_vhdl.html#sthash.UFLcTc7E.dpuf

--- a/src/ghdldrv/ghdlprint.adb
+++ b/src/ghdldrv/ghdlprint.adb
@@ -466,8 +466,8 @@ package body Ghdlprint is
       end case;
       --Put_Line ("<?xml version=""1.0"" encoding=""utf-8"" ?>");
       --Put_Line("<!DOCTYPE html PUBLIC ""-//W3C//DTD XHTML 1.0 Strict//EN""");
-      --Put_Line ("""http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd"">");
-      --Put_Line ("<html xmlns=""http://www.w3.org/1999/xhtml"""
+      --Put_Line ("""https://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd"">");
+      --Put_Line ("<html xmlns=""https://www.w3.org/1999/xhtml"""
       --         & " xml:lang=""en"">");
       --Put_Line ("<head>");
    end Put_Html_Header;

--- a/src/grt/fst/lz4.c
+++ b/src/grt/fst/lz4.c
@@ -27,7 +27,7 @@
    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
    You can contact the author at :
-   - LZ4 source repository : http://code.google.com/p/lz4/
+   - LZ4 source repository : https://github.com/Cyan4973/lz4
    - LZ4 public forum : https://groups.google.com/forum/#!forum/lz4c
 */
 

--- a/src/grt/fst/lz4.h
+++ b/src/grt/fst/lz4.h
@@ -28,7 +28,7 @@
    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
    You can contact the author at :
-   - LZ4 source repository : http://code.google.com/p/lz4/
+   - LZ4 source repository : https://github.com/Cyan4973/lz4
    - LZ4 public forum : https://groups.google.com/forum/#!forum/lz4c
 */
 #pragma once

--- a/src/vhdl/iirs.ads
+++ b/src/vhdl/iirs.ads
@@ -25,7 +25,7 @@ package Iirs is
    --  This package defines the semantic tree and functions to handle it.
    --  The tree is roughly based on IIR (Internal Intermediate Representation),
    --  [AIRE/CE Advanced Intermediate Representation with Extensibility,
-   --   Common Environment.  http://www.vhdl.org/aire/index.html ]
+   --   Common Environment.  http://www.vhdl.org/aire/index.html [DEAD LINK] ]
    --  but oriented object features are not used, and sometimes, functions
    --  or fields have changed.
 

--- a/testsuite/gna/testsuite.sh
+++ b/testsuite/gna/testsuite.sh
@@ -7,7 +7,7 @@
 # bug0XX is for bugs not reported.
 # bug[1-9]XXX is for bugs reported on https://gna.org/bugs/?group=ghdl
 # srXXX is for support reported on https://gna.org/support/?group=ghdl
-# debXX is for bugs report on http://bugs.debian.org/
+# debXX is for bugs report on https://www.debian.org/Bugs/
 # ticketXX is from https://sourceforge.net/p/ghdl-updates/tickets/
 # issueXXX is from https://github.com/tgingold/ghdl/issues
 

--- a/testsuite/gna/ticket89/x_ieee_proposed/src/README
+++ b/testsuite/gna/ticket89/x_ieee_proposed/src/README
@@ -160,7 +160,7 @@ use ieee.numeric_std.all;
 use ieee_proposed.math_utility_pkg.all;
 use ieee_proposed.fixed_pkg.all;
 See fixed point package documentation
-http://www.vhdl.org/vhdl-200x/vhdl-200x-ft/packages/Fixed_ug.pdf
+http://www.vhdl.org/vhdl-200x/vhdl-200x-ft/packages/Fixed_ug.pdf [DEAD LINK]
 
 G) For floating point package:
 use model:
@@ -170,4 +170,4 @@ use ieee_proposed.math_utility_pkg.all;
 use ieee_proposed.fixed_pkg.all;
 use ieee_proposed.float_pkg.all;
 See floating point package documentation
-http://www.vhdl.org/vhdl-200x/vhdl-200x-ft/packages/Float_ug.pdf
+http://www.vhdl.org/vhdl-200x/vhdl-200x-ft/packages/Float_ug.pdf [DEAD LINK]


### PR DESCRIPTION
Looking to make drive-by contributions, I noticed that there are a lot of `http://...` links that easily could be replaced by `https://...` links, which are usually deemed "safer".

As you might have objections to the reliability of certain hosts to stick with https, this path is split up by hostname.  I manually verified each unique URL to work properly.

Finally, there are a few links which are now invalid: see the last commit for that, which marks the dead links as such:
- The lz4 repository seems to now live at [https://github.com/Cyan4973/lz4]. so I'll contact upstream about getting that fixed eventually.
- I have no idea where the `vhdl.org` might have gone

This is the command I have grown while searching for non-`https` links:
```
grep -nrF http: . | grep -vF '//ghdl.free.fr' | grep -vF '//libre.adacore.com' | grep -vF '//osvvm.org' | grep -vF '//kassiopeia.juls.savba.sk' | grep -vF '//burtleburtle.net' | grep -vF '//www.opensource.org' | grep -vF '//www.xilinx.com' | grep -vF '//www.eecg.toronto.edu'
```
Fun fact: this is simultaneously the list of all webmasters that haven't switched to https, or did so incorrectly.