### PR TITLE
Adding support for a wave option file that selects signals to be disp…

### DIFF
--- a/src/grt/grt-options.adb
+++ b/src/grt/grt-options.adb
@@ -28,6 +28,7 @@ with Grt.Errors; use Grt.Errors;
 with Grt.Stdio; use Grt.Stdio;
 with Grt.Astdio;
 with Grt.Hooks;
+with Grt.Wave_Options.Parse;
 
 package body Grt.Options is
 
@@ -480,6 +481,9 @@ package body Grt.Options is
             end if;
             Last_Generic_Override := Over;
          end;
+      elsif Option'Length >= 18 and then
+            Option (1 .. 19) = "--wave-option-file=" then
+         Wave_Options.Parse.Start (Option (20 .. Option'Last));
       elsif Option = "--unbuffered" then
          Unbuffered_Writes := True;
          setbuf (stdout, NULL_voids);

--- a/src/grt/grt-strings.adb
+++ b/src/grt/grt-strings.adb
@@ -30,6 +30,46 @@ package body Grt.Strings is
       return C = ' ' or C = NBSP or C = HT;
    end Is_Whitespace;
 
+   function First_Non_Whitespace_Pos (Str : String) return Integer is
+   begin
+      for Index in Str'Range loop
+         if not Is_Whitespace (Str (Index)) then
+            return Index;
+         end if;
+      end loop;
+      return -1;
+   end First_Non_Whitespace_Pos;
+
+   function Last_Non_Whitespace_Pos (Str : String) return Integer is
+   begin
+      for Index in reverse Str'Range loop
+         if not Is_Whitespace (Str (Index)) then
+            return Index;
+         end if;
+      end loop;
+      return -1;
+   end Last_Non_Whitespace_Pos;
+
+   function New_Line_Pos (Line : String) return Integer is
+   begin
+      return Find (Line, ASCII.LF);
+   end New_Line_Pos;
+
+   function Find (Str : String; Char : Character) return Integer is
+   begin
+      for Index in Str'Range loop
+         if Str (Index) = Char then
+            return Index;
+         end if;
+      end loop;
+      return -1;
+   end Find;
+   function Find (Str : String; Char : Character; Start : Positive)
+            return Integer is
+   begin
+      return Find (Str (Start .. Str'Last), Char);
+   end Find;
+
    function To_Lower (C : Character) return Character is
    begin
       if C in 'A' .. 'Z' then
@@ -38,4 +78,37 @@ package body Grt.Strings is
          return C;
       end if;
    end To_Lower;
+
+   procedure To_Lower (S : in out String) is
+   begin
+      for I in S'Range loop
+         S (I) := To_Lower (S (I));
+      end loop;
+   end To_Lower;
+
+   function Value (Str : String) return Integer is
+      Decimal : Positive := 1;
+      Value_Tmp : Natural := 0;
+      Digit : Integer;
+   begin
+      for Index in reverse Str'Range loop
+         Digit := Value (Str (Index));
+         if Digit = -1 then
+            return -1;
+         end if;
+         Value_Tmp := Value_Tmp + Digit * Decimal;
+         Decimal := Decimal * 10;
+      end loop;
+      return Value_Tmp;
+   end Value;
+
+   function Value (Char : Character) return Integer is
+   begin
+      case Char is
+      when '0' .. '9' =>
+         return Character'Pos (Char) - Character'Pos ('0');
+      when others =>
+         return -1;
+      end case;
+   end Value;
 end Grt.Strings;

--- a/src/grt/grt-vstrings.ads
+++ b/src/grt/grt-vstrings.ads
@@ -27,6 +27,7 @@ with Grt.Types; use Grt.Types;
 with System; use System;
 
 package Grt.Vstrings is
+   pragma Preelaborate;
    --  A Vstring (Variable string) is an object which contains an unbounded
    --  string.
    type Vstring is limited private;

--- a/src/grt/grt-wave_options-parse-debug.adb
+++ b/src/grt/grt-wave_options-parse-debug.adb
@@ -1,5 +1,5 @@
---  GHDL Run Time (GRT) - Misc subprograms for characters and strings
---  Copyright (C) 2016 Tristan Gingold
+--  GHDL Run Time (GRT) - mono-thread version.
+--  Copyright (C) 2005 - 2014 Tristan Gingold
 --
 --  GHDL is free software; you can redistribute it and/or modify it under
 --  the terms of the GNU General Public License as published by the Free
@@ -23,24 +23,36 @@
 --  however invalidate any other reasons why the executable file might be
 --  covered by the GNU Public License.
 
-package Grt.Strings is
-   pragma Pure;
+with Grt.Astdio; use Grt.Astdio;
 
-   NBSP : constant Character := Character'Val (160);
+package body Grt.Wave_Options.Parse.Debug is
 
-   --  Return True IFF C is a whitespace character (as defined in LRM93 14.3)
-   function Is_Whitespace (C : in Character) return Boolean;
-   function First_Non_Whitespace_Pos (Str : String) return Integer;
-   function Last_Non_Whitespace_Pos (Str : String) return Integer;
-   function New_Line_Pos (Line : String) return Integer;
-   function Find (Str : String; Char : Character) return Integer;
-   function Find (Str : String; Char : Character; Start : Positive) return Integer;
+   procedure Dump_Tree is
+   begin
+      for Index in Tree_Index_Type'Range loop
+         New_Line; New_Line; Put ("----------------------------"); New_Line;
+         if Index = Pkg then
+            Put ("Packages : ");
+         else
+            Put ("Instances : ");
+         end if;
+         New_Line;
+         Dump_Sub_Tree (Trees (Index), 1);
+      end loop;
+      Put ("----------- END -----------------"); New_Line;
+   end Dump_Tree;
 
-   --  Convert C/S to lowercase.
-   function To_Lower (C : Character) return Character;
-   procedure To_Lower (S : in out String);
+   procedure Dump_Sub_Tree (Previous_Cursor : Elem_Acc; Level : Positive) is
+      Current_Cursor : Elem_Acc := Previous_Cursor;
+   begin
+      while Current_Cursor /= null loop
+         for i in 2 .. Level loop
+            Put ("   ");
+         end loop;
+         Put ('/'); Put (Current_Cursor.Name.all); New_Line;
+         Dump_Sub_Tree (Current_Cursor.Next_Child, Level + 1);
+         Current_Cursor := Current_Cursor.Next_Sibling;
+      end loop;
+   end Dump_Sub_Tree;
 
-   -- Str/Char : image of a natural number/digit
-   function Value (Str : String) return Integer;
-   function Value (Char : Character) return Integer;
-end Grt.Strings;
+end Grt.Wave_Options.Parse.Debug;

--- a/src/grt/grt-wave_options-parse-debug.ads
+++ b/src/grt/grt-wave_options-parse-debug.ads
@@ -1,5 +1,5 @@
---  GHDL Run Time (GRT) - Misc subprograms for characters and strings
---  Copyright (C) 2016 Tristan Gingold
+--  GHDL Run Time (GRT) - mono-thread version.
+--  Copyright (C) 2005 - 2014 Tristan Gingold
 --
 --  GHDL is free software; you can redistribute it and/or modify it under
 --  the terms of the GNU General Public License as published by the Free
@@ -23,24 +23,10 @@
 --  however invalidate any other reasons why the executable file might be
 --  covered by the GNU Public License.
 
-package Grt.Strings is
-   pragma Pure;
+private package Grt.Wave_Options.Parse.Debug is
+   pragma Preelaborate;
 
-   NBSP : constant Character := Character'Val (160);
+   procedure Dump_Tree;
+   procedure Dump_Sub_Tree (Previous_Cursor : Elem_Acc; Level : Positive);
 
-   --  Return True IFF C is a whitespace character (as defined in LRM93 14.3)
-   function Is_Whitespace (C : in Character) return Boolean;
-   function First_Non_Whitespace_Pos (Str : String) return Integer;
-   function Last_Non_Whitespace_Pos (Str : String) return Integer;
-   function New_Line_Pos (Line : String) return Integer;
-   function Find (Str : String; Char : Character) return Integer;
-   function Find (Str : String; Char : Character; Start : Positive) return Integer;
-
-   --  Convert C/S to lowercase.
-   function To_Lower (C : Character) return Character;
-   procedure To_Lower (S : in out String);
-
-   -- Str/Char : image of a natural number/digit
-   function Value (Str : String) return Integer;
-   function Value (Char : Character) return Integer;
-end Grt.Strings;
+end Grt.Wave_Options.Parse.Debug;

--- a/src/grt/grt-wave_options-parse.adb
+++ b/src/grt/grt-wave_options-parse.adb
@@ -1,0 +1,317 @@
+--  GHDL Run Time (GRT) -  command line options.
+--  Copyright (C) 2002 - 2014 Tristan Gingold
+--
+--  GHDL is free software; you can redistribute it and/or modify it under
+--  the terms of the GNU General Public License as published by the Free
+--  Software Foundation; either version 2, or (at your option) any later
+--  version.
+--
+--  GHDL is distributed in the hope that it will be useful, but WITHOUT ANY
+--  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+--  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+--  for more details.
+--
+--  You should have received a copy of the GNU General Public License
+--  along with GCC; see the file COPYING.  If not, write to the Free
+--  Software Foundation, 59 Temple Place - Suite 330, Boston, MA
+--  02111-1307, USA.
+--
+--  As a special exception, if other files instantiate generics from this
+--  unit, or you link this unit with other files to produce an executable,
+--  this unit does not by itself cause the resulting executable to be
+--  covered by the GNU General Public License. This exception does not
+--  however invalidate any other reasons why the executable file might be
+--  covered by the GNU Public License.
+
+with System; use System;
+with Grt.Types; use Grt.Types;
+with Grt.Strings; use Grt.Strings;
+with Grt.Vstrings; use Grt.Vstrings;
+with Grt.Errors; use Grt.Errors;
+
+with Grt.Wave_Options.Parse.Debug;
+
+package body Grt.Wave_Options.Parse is
+
+   procedure Start (Option_File : String) is
+      Stream : FILEs := File_Open (Option_File);
+      First, Last : Integer;
+      Line : String (1 .. Buf_Size);
+      Lineno : Natural;
+   begin
+      File_Path := new String'(Option_File);
+      Lineno := 0;
+
+      loop -- Reads line after line
+         exit when fgets (Line'Address, Line'Length, Stream) = Null_Address;
+         Lineno := Lineno + 1;
+
+         Last := New_Line_Pos (Line) - 1;
+         if Last < 0 then
+            Last := Line'Last;
+         end if;
+
+         First := First_Non_Whitespace_Pos (Line (Line'First .. Last));
+         if First = -1 or else Line (First) = '#' then
+            goto Continue;
+         end if;
+
+         Last := Last_Non_Whitespace_Pos (Line (First .. Last));
+         declare
+            Line_Str : String (1 .. Last + 1 - First) := Line (First .. Last);
+         begin
+            Line_Context :=
+               new Line_Context_Type'(Str => new String'(Line_Str),
+                                      Num => Lineno,
+                                      Max_Level => 0);
+         end;
+
+         if Line (First) = '$' then
+            Parse_Version (Line_Context.Str);
+         else
+            Parse_Path (Line_Context.Str);
+         end if;
+
+         <<Continue>> null;
+      end loop;
+
+      if Version.Major = -1 then
+         Report_C ("warning: version wasn't set at the beginning of the file;" &
+                   " currently supported version is ");
+         Print_Version (Current_Version);
+         Newline_Err;
+      end if;
+
+      if Trees = Tree_Array'(others => null) then
+         Report_E ("No signal path was found in the wave option file," &
+                   "then every signals will be displayed.");
+      end if;
+
+      --~ Debug.Dump_Tree;
+
+   end Start;
+
+-- private ---------------------------------------------------------------------
+
+   procedure Parse_Version (Line : String_Acc) is
+      Msg_Invalid_Format : constant String := "invalid version format";
+      First, Dot_Index, Num : Integer;
+   begin
+
+      if Version /= (others => -1) then
+         Error_Context ("version is set more than once");
+      end if;
+
+      if Trees /= Tree_Array'(others => null) then
+         Error_Context ("version cannot be set after signal paths");
+      end if;
+
+      First := First_Non_Whitespace_Pos (Line (Line'First + 1 .. Line'Last));
+      if Line (First .. First + 6) /= "version" then
+         Error_Context (Msg_Invalid_Format);
+      end if;
+
+      First := First + 7;
+      if not Is_Whitespace (Line (First)) then --catch "version\n", "version1.0"
+         Error_Context (Msg_Invalid_Format);
+      end if;
+
+      First := First_Non_Whitespace_Pos (Line (First + 1 .. Line'Last));
+      if First = -1 then -- catch "version \n", "version  \n", etc
+         Error_Context (Msg_Invalid_Format);
+      end if;
+
+      Dot_Index := Find (Line (First + 1 .. Line'Last), '.');
+      if Dot_Index = -1 then -- catch the absence of "." or "version ."
+         Error_Context (Msg_Invalid_Format);
+      end if;
+
+      Num := Value (Line (First .. Dot_Index - 1));
+      if Num = -1 then -- catch version a.2
+         Error_Context (Msg_Invalid_Format);
+      end if;
+      Version.Major := Num;
+
+      Num := Value (Line (Dot_Index + 1 .. Line'Last));
+      if Num = -1 then -- catch version 1.a
+         Error_Context (Msg_Invalid_Format);
+      end if;
+      Version.Minor := Num;
+
+      if Version.Major /= Current_Version.Major
+        or else Version.Minor > Current_Version.Minor
+      then
+         Print_Context (Error);
+         Error_C ("unsupported format version; it must be ");
+         if Current_Version.Minor /= 0 then
+            Error_C ("between ");
+            Print_Version (Version_Type'(Current_Version.Major, 0));
+            Error_C (" and ");
+         end if;
+         Print_Version (Current_Version);
+         Error_E;
+      end if;
+
+   end Parse_Version;
+
+   procedure Print_Version (Version : Version_Type) is
+      Num_Str : String (1 .. Value_String_Size);
+      First : Positive;
+   begin
+      To_String (Num_Str, First, Ghdl_I32 (Version.Major));
+      Report_C (Num_Str (First .. Num_Str'Last));
+      Report_C (".");
+      To_String (Num_Str, First, Ghdl_I32 (Version.Minor));
+      Report_C (Num_Str (First .. Num_Str'Last));
+   end Print_Version;
+
+   --------------------------------------------------------------------------
+
+   procedure Parse_Path (Line : String_Acc) is
+      First, Last : Positive;
+      Tree_Updated : Boolean;
+      Tree_Index : Tree_Index_Type;
+   begin
+      To_Lower (Line_Context.Str.all);
+      Last := Line'First;
+      if Line (Line'First) = '/' then
+         Tree_Index := Entity;
+         Last := Last + 1;
+      else
+         Tree_Index := Pkg;
+      end if;
+      Tree_Cursor := Trees (Tree_Index);
+      Previous_Tree_Cursor := null;
+
+      loop
+         First := Last;
+
+         loop -- Find next identifier
+            if Line (Last) = Sep (Tree_Index) then
+               Last := Last - 1;
+               exit;
+            elsif Last = Line'Last then
+               exit;
+            end if;
+            Last := Last + 1;
+         end loop;
+
+         Check_Validity (Line (First .. Last));
+         Tree_Updated := Update_Tree (Line (First .. Last), Tree_Index);
+         Line_Context.Max_Level := Line_Context.Max_Level + 1;
+
+         if Last = Line'Last then
+            if not Tree_Updated then
+               Error_Context ("ignored already known signal path", Warning);
+            end if;
+            return;
+         end if;
+
+         Last := Last + 2; -- Skip the separator
+         if Last > Line'Last then -- catch signal paths ending with /
+            Error_Context ("invalid signal path");
+         end if;
+
+      end loop;
+
+   end Parse_Path;
+
+   function Update_Tree (Elem_Name : String; Tree_Index : Tree_Index_Type)
+            return Boolean is
+      Sibling_Cursor : Elem_Acc := Tree_Cursor;
+      Previous_Sibling_Cursor : Elem_Acc := null;
+      Elem : Elem_Acc;
+   begin
+      loop
+         -- Already reached the last sibling and current identifier corresponds
+         -- to no existing element ? Then we will create an element
+         if Sibling_Cursor = null then
+            Elem := new Elem_Type'(Name => new String'(Elem_Name),
+                                   Line_Context => Line_Context,
+                                   Kind => Not_Found,
+                                   Next_Sibling | Next_Child => null);
+            if Previous_Sibling_Cursor = null then -- First element of level ?
+               if Previous_Tree_Cursor = null then -- Is a top_level ?
+                  Trees (Tree_Index) := Elem;
+               else
+                  Previous_Tree_Cursor.Next_Child := Elem;
+               end if;
+            else
+               Previous_Sibling_Cursor.Next_Sibling := Elem;
+            end if;
+            Previous_Tree_Cursor := Elem;
+            Tree_Cursor := null; -- Point to Elem.Next_Child which is null
+            return True;
+         -- Identifier was found in the tree ? Then move to its first child
+         elsif Elem_Name = Sibling_Cursor.Name.all then
+            Previous_Tree_Cursor := Sibling_Cursor;
+            Tree_Cursor := Sibling_Cursor.Next_Child;
+            return False;
+         end if;
+         Previous_Sibling_Cursor := Sibling_Cursor;
+         Sibling_Cursor := Sibling_Cursor.Next_Sibling;
+      end loop;
+   end Update_Tree;
+
+   procedure Check_Validity (Elem_Name : String) is
+   begin
+      if Elem_Name'Length = 0 then
+         Error_Context ("invalid signal path");
+      end if;
+      for Index in Elem_Name'Range loop
+         case Elem_Name (Index) is
+         when 'A' .. 'Z' | 'a' .. 'z' =>
+            null;
+         when '0' .. '9' =>
+            if Index = Elem_Name'First then
+               Validity_Error (Elem_Name);
+            end if;
+         when '_' =>
+            if Index = Elem_Name'First
+              or else Index = Elem_Name'Last
+              or else Elem_Name (Index - 1) = '_'
+            then
+               Validity_Error (Elem_Name);
+            end if;
+         when '.' | '/' =>
+            Error_Context ("invalid signal path");
+         when others =>
+            Validity_Error (Elem_Name);
+         end case;
+      end loop;
+   end Check_Validity;
+
+   procedure Validity_Error (Elem_Name : String) is
+   begin
+      Print_Context (Error);
+      Error_C ("object name '");
+      Error_C (Elem_Name);
+      Error_E ("' is not a valid VHDL name");
+   end Validity_Error;
+
+   --------------------------------------------------------------------------
+
+   procedure Print_Context (Severity : Severity_Type) is
+   begin
+      Print_Context (Line_Context, Severity);
+   end Print_Context;
+
+   procedure Error_Context (Msg : String; Severity : Severity_Type := Error) is
+   begin
+      Error_Context (Msg, Line_Context, Severity);
+   end Error_Context;
+
+   function File_Open (Option_File : String) return FILEs is
+      Mode : constant String := "rt" & ASCII.Nul;
+      Stream : FILEs;
+   begin
+      Stream := fopen (Option_File'Address, Mode'Address);
+      if Stream = NULL_Stream then
+         Error_C ("cannot open '");
+         Error_C (Option_File (Option_File'First .. Option_File'Last - 1));
+         Error_E ("'");
+      end if;
+      return Stream;
+   end File_Open;
+
+end Grt.Wave_Options.Parse;

--- a/src/grt/grt-wave_options-parse.ads
+++ b/src/grt/grt-wave_options-parse.ads
@@ -1,0 +1,64 @@
+--  GHDL Run Time (GRT) - mono-thread version.
+--  Copyright (C) 2005 - 2014 Tristan Gingold
+--
+--  GHDL is free software; you can redistribute it and/or modify it under
+--  the terms of the GNU General Public License as published by the Free
+--  Software Foundation; either version 2, or (at your option) any later
+--  version.
+--
+--  GHDL is distributed in the hope that it will be useful, but WITHOUT ANY
+--  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+--  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+--  for more details.
+--
+--  You should have received a copy of the GNU General Public License
+--  along with GCC; see the file COPYING.  If not, write to the Free
+--  Software Foundation, 59 Temple Place - Suite 330, Boston, MA
+--  02111-1307, USA.
+--
+--  As a special exception, if other files instantiate generics from this
+--  unit, or you link this unit with other files to produce an executable,
+--  this unit does not by itself cause the resulting executable to be
+--  covered by the GNU General Public License. This exception does not
+--  however invalidate any other reasons why the executable file might be
+--  covered by the GNU Public License.
+
+with Grt.Stdio; use Grt.Stdio;
+
+package Grt.Wave_Options.Parse is
+   pragma Preelaborate;
+
+   procedure Start (Option_File : String);
+
+private
+
+   Buf_Size : constant := 1024;
+
+   Line_Context : Line_Context_Acc;
+
+   Tree_Cursor, Previous_Tree_Cursor : Elem_Acc;
+
+   type Version_Type is record
+      Major : Integer;
+      Minor : Integer;
+   end record;
+   Version : Version_Type := (others => -1);
+   Current_Version : constant Version_Type := (Major => 1, Minor => 0);
+
+   type Sep_Array is array (Tree_Index_Type) of Character;
+   Sep : constant Sep_Array := (Pkg => '.', Entity => '/');
+
+   procedure Parse_Version (Line : String_Acc);
+   procedure Print_Version (Version : Version_Type);
+
+   procedure Parse_Path (Line : String_Acc);
+   function Update_Tree (Elem_Name : String; Tree_Index : Tree_Index_Type)
+            return Boolean;
+   procedure Check_Validity (Elem_Name : String);
+   procedure Validity_Error (Elem_Name : String);
+
+   procedure Print_Context (Severity : Severity_Type);
+   procedure Error_Context (Msg : String; Severity : Severity_Type := Error);
+   function File_Open (Option_File : String) return FILEs;
+
+end Grt.Wave_Options.Parse;

--- a/src/grt/grt-wave_options-read.adb
+++ b/src/grt/grt-wave_options-read.adb
@@ -1,0 +1,125 @@
+--  GHDL Run Time (GRT) -  command line options.
+--  Copyright (C) 2002 - 2014 Tristan Gingold
+--
+--  GHDL is free software; you can redistribute it and/or modify it under
+--  the terms of the GNU General Public License as published by the Free
+--  Software Foundation; either version 2, or (at your option) any later
+--  version.
+--
+--  GHDL is distributed in the hope that it will be useful, but WITHOUT ANY
+--  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+--  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+--  for more details.
+--
+--  You should have received a copy of the GNU General Public License
+--  along with GCC; see the file COPYING.  If not, write to the Free
+--  Software Foundation, 59 Temple Place - Suite 330, Boston, MA
+--  02111-1307, USA.
+--
+--  As a special exception, if other files instantiate generics from this
+--  unit, or you link this unit with other files to produce an executable,
+--  this unit does not by itself cause the resulting executable to be
+--  covered by the GNU General Public License. This exception does not
+--  however invalidate any other reasons why the executable file might be
+--  covered by the GNU Public License.
+
+with Grt.Strings; use Grt.Strings;
+with Grt.Errors; use Grt.Errors;
+
+package body Grt.Wave_Options.Read is
+
+   function Get_Top_Cursor (Name : Ghdl_C_String; Index : Tree_Index_Type)
+            return Elem_Acc is
+   begin
+      return Find_Cursor (Name, Trees (Index));
+   end Get_Top_Cursor;
+
+   function Get_Cursor (Name : Ghdl_C_String; Parent : Elem_Acc;
+            Is_Signal : Boolean := False) return Elem_Acc is
+   begin
+      if Display_All_Signals then
+         return null;
+      end if;
+      return Find_Cursor (Name, Parent.Next_Child, Is_Signal);
+   end Get_Cursor;
+
+   function Is_Displayed (Cursor : Elem_Acc) return Boolean is
+   begin
+      if Display_All_Signals or else Cursor /= null then
+         return True;
+      end if;
+      return False;
+   end Is_Displayed;
+
+   procedure Check_If_All_Found is
+   begin
+      for Index in Tree_Index_Type'Range loop
+         Check_If_Found (Trees (Index), Seps (Index), 1);
+      end loop;
+   end Check_If_All_Found;
+
+-- private ---------------------------------------------------------------------
+
+   function Find_Cursor (Name : Ghdl_C_String; First : Elem_Acc;
+            Is_Signal : Boolean := False) return Elem_Acc is
+      Len : constant Natural := strlen (Name);
+      Cursor : Elem_Acc := First;
+   begin
+      loop
+         if Cursor = null then
+            return null;
+         elsif Cursor.Name.all = Name (1 .. Len) then
+            if Is_Signal then
+               Cursor.Kind := Signal;
+            else
+               Cursor.Kind := Pkg_Entity;
+            end if;
+            return Cursor;
+         end if;
+         Cursor := Cursor.Next_Sibling;
+      end loop;
+   end Find_Cursor;
+
+   procedure Check_If_Found (Previous_Cursor : Elem_Acc;
+                             Sep : Character; Level : Positive) is
+      Cursor : Elem_Acc := Previous_Cursor;
+      Index : Positive;
+   begin
+      while Cursor /= null loop
+         if Cursor.Kind = Not_Found then
+            Print_Context (Cursor.Line_Context, Warning);
+            Report_C ("no VHDL object in design matches ");
+            -- Display the path of the first unfound vhdl object in signal path
+            if Level > 1 then
+               Index := 1;
+               for I in 2 .. Level loop
+                  Index := Find (Cursor.Line_Context.Str.all, Sep, Index + 1);
+               end loop;
+               Report_C (Cursor.Line_Context.Str (Cursor.Line_Context.Str'First
+                                                  .. Index));
+            elsif Sep = '/' then
+               Report_C ("/");
+            end if;
+            Report_E (Cursor.Name.all);
+         elsif Level = Cursor.Line_Context.Max_Level
+           and then Cursor.Kind = Pkg_Entity
+         then
+            Error_Context ("not a signal", Cursor.Line_Context, Warning);
+         else
+            Check_If_Found (Cursor.Next_Child, Sep, Level + 1);
+         end if;
+         Cursor := Cursor.Next_Sibling;
+      end loop;
+
+   end Check_If_Found;
+
+   function Display_All_Signals return Boolean is
+   begin
+      if Trees = Tree_Array'(others => null) then
+         return True;
+      end if;
+      return False;
+   end Display_All_Signals;
+
+
+end Grt.Wave_Options.Read;

--- a/src/grt/grt-wave_options-read.ads
+++ b/src/grt/grt-wave_options-read.ads
@@ -1,5 +1,5 @@
---  GHDL Run Time (GRT) - Misc subprograms for characters and strings
---  Copyright (C) 2016 Tristan Gingold
+--  GHDL Run Time (GRT) - mono-thread version.
+--  Copyright (C) 2005 - 2014 Tristan Gingold
 --
 --  GHDL is free software; you can redistribute it and/or modify it under
 --  the terms of the GNU General Public License as published by the Free
@@ -23,24 +23,27 @@
 --  however invalidate any other reasons why the executable file might be
 --  covered by the GNU Public License.
 
-package Grt.Strings is
-   pragma Pure;
+with Grt.Types; use Grt.Types;
 
-   NBSP : constant Character := Character'Val (160);
+package Grt.Wave_Options.Read is
+   pragma Preelaborate;
 
-   --  Return True IFF C is a whitespace character (as defined in LRM93 14.3)
-   function Is_Whitespace (C : in Character) return Boolean;
-   function First_Non_Whitespace_Pos (Str : String) return Integer;
-   function Last_Non_Whitespace_Pos (Str : String) return Integer;
-   function New_Line_Pos (Line : String) return Integer;
-   function Find (Str : String; Char : Character) return Integer;
-   function Find (Str : String; Char : Character; Start : Positive) return Integer;
+   function Get_Top_Cursor (Name : Ghdl_C_String; Index : Tree_Index_Type)
+            return Elem_Acc;
+   function Get_Cursor (Name : Ghdl_C_String; Parent : Elem_Acc;
+            Is_Signal : Boolean := False) return Elem_Acc;
+   function Is_Displayed (Cursor : Elem_Acc) return Boolean;
 
-   --  Convert C/S to lowercase.
-   function To_Lower (C : Character) return Character;
-   procedure To_Lower (S : in out String);
+   procedure Check_If_All_Found;
 
-   -- Str/Char : image of a natural number/digit
-   function Value (Str : String) return Integer;
-   function Value (Char : Character) return Integer;
-end Grt.Strings;
+private
+
+   function Find_Cursor (Name : Ghdl_C_String; First : Elem_Acc;
+            Is_Signal : Boolean := False) return Elem_Acc;
+
+   procedure Check_If_Found (Previous_Cursor : Elem_Acc;
+                             Sep : Character; Level : Positive);
+
+   function Display_All_Signals return Boolean;
+
+end Grt.Wave_Options.Read;

--- a/src/grt/grt-wave_options.adb
+++ b/src/grt/grt-wave_options.adb
@@ -1,0 +1,66 @@
+--  GHDL Run Time (GRT) -  command line options.
+--  Copyright (C) 2002 - 2014 Tristan Gingold
+--
+--  GHDL is free software; you can redistribute it and/or modify it under
+--  the terms of the GNU General Public License as published by the Free
+--  Software Foundation; either version 2, or (at your option) any later
+--  version.
+--
+--  GHDL is distributed in the hope that it will be useful, but WITHOUT ANY
+--  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+--  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+--  for more details.
+--
+--  You should have received a copy of the GNU General Public License
+--  along with GCC; see the file COPYING.  If not, write to the Free
+--  Software Foundation, 59 Temple Place - Suite 330, Boston, MA
+--  02111-1307, USA.
+--
+--  As a special exception, if other files instantiate generics from this
+--  unit, or you link this unit with other files to produce an executable,
+--  this unit does not by itself cause the resulting executable to be
+--  covered by the GNU General Public License. This exception does not
+--  however invalidate any other reasons why the executable file might be
+--  covered by the GNU Public License.
+
+with Grt.Types; use Grt.Types;
+with Grt.Strings; use Grt.Strings;
+with Grt.Vstrings; use Grt.Vstrings;
+with Grt.Errors; use Grt.Errors;
+
+package body Grt.Wave_Options is
+
+   procedure Print_Context (Line_Context : Line_Context_Acc;
+                            Severity : Severity_Type) is
+      Lineno_Str : String (1 .. Value_String_Size);
+      First : Natural;
+   begin
+      case Severity is
+      when Error =>
+         Error_C ("");
+      when Warning =>
+         Report_C ("warning: ");
+      end case;
+      Report_C ("in file '");
+      Report_C (File_Path.all);
+      Report_C ("' at line ");
+      To_String (Lineno_Str, First, Ghdl_I32 (Line_Context.Num));
+      Report_C (Lineno_Str (First .. Lineno_Str'Last));
+      Report_C (" - ");
+      Report_C (Line_Context.Str.all);
+      Report_C (" : ");
+   end Print_Context;
+
+   procedure Error_Context (Msg : String; Line_Context : Line_Context_Acc;
+                            Severity : Severity_Type := Error) is
+   begin
+      Print_Context (Line_Context, Severity);
+      case Severity is
+      when Error =>
+         Error_E (Msg);
+      when Warning =>
+         Report_E (Msg);
+      end case;
+   end Error_Context;
+
+end Grt.Wave_Options;

--- a/src/grt/grt-wave_options.ads
+++ b/src/grt/grt-wave_options.ads
@@ -1,0 +1,66 @@
+--  GHDL Run Time (GRT) - mono-thread version.
+--  Copyright (C) 2005 - 2014 Tristan Gingold
+--
+--  GHDL is free software; you can redistribute it and/or modify it under
+--  the terms of the GNU General Public License as published by the Free
+--  Software Foundation; either version 2, or (at your option) any later
+--  version.
+--
+--  GHDL is distributed in the hope that it will be useful, but WITHOUT ANY
+--  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+--  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+--  for more details.
+--
+--  You should have received a copy of the GNU General Public License
+--  along with GCC; see the file COPYING.  If not, write to the Free
+--  Software Foundation, 59 Temple Place - Suite 330, Boston, MA
+--  02111-1307, USA.
+--
+--  As a special exception, if other files instantiate generics from this
+--  unit, or you link this unit with other files to produce an executable,
+--  this unit does not by itself cause the resulting executable to be
+--  covered by the GNU General Public License. This exception does not
+--  however invalidate any other reasons why the executable file might be
+--  covered by the GNU Public License.
+
+package Grt.Wave_Options is
+   pragma Preelaborate;
+
+   type String_Acc is access String;
+   type String_Cst is access constant String;
+   Value_String_Size : constant := 10;
+
+   File_Path : String_Cst;
+
+   type Line_Context_Type is record
+      Str : String_Acc;
+      Num : Natural;
+      Max_Level : Natural;
+   end record;
+   type Line_Context_Acc is access Line_Context_Type;
+
+   type Elem_Kind_Type is (Not_Found, Pkg_Entity, Signal);
+   type Elem_Type;
+   type Elem_Acc is access Elem_Type;
+   type Elem_Type is record
+      Name : String_Cst;
+      Line_Context : Line_Context_Acc;
+      Kind : Elem_Kind_Type;
+      Next_Sibling : Elem_Acc;
+      Next_Child : Elem_Acc;
+   end record;
+
+   type Tree_Index_Type is (Pkg, Entity);
+   type Tree_Array is array (Tree_Index_Type) of Elem_Acc;
+   Trees : Tree_Array := (others => null);
+   type Sep_Array is array (Tree_Index_Type) of Character;
+   Seps : constant Sep_Array := (Pkg => '.', Entity => '/');
+
+   type Severity_Type is (Error, Warning);
+
+   procedure Print_Context (Line_Context : Line_Context_Acc;
+                            Severity : Severity_Type);
+   procedure Error_Context (Msg : String; Line_Context : Line_Context_Acc;
+                            Severity : Severity_Type := Error);
+
+end Grt.Wave_Options;


### PR DESCRIPTION
Adding support for a wave option file that selects signals to be displayed on the waveform (currently only works with the ghw wave format). Only full signal paths are supported now (no wildcards). Wave option file version set to 1.0.