### PR TITLE
Reworked compile scripts for Windows.

### DIFF
--- a/dist/mcode/windows/compile-ghdl.ps1
+++ b/dist/mcode/windows/compile-ghdl.ps1
@@ -35,216 +35,221 @@
 #	Software Foundation, 59 Temple Place - Suite 330, Boston, MA
 #	02111-1307, USA.
 # ==============================================================================
-<#
-	.SYNOPSIS 
-	GHDL for Windows - GHDL compile script
-	Use 'compile.ps1 -Help' to see the integrated help page
-	
-	.EXAMPLE
-	C:\PS> .\compile.ps1 -Clean -Compile
-#>
 
-# define script parameters
+# .SYNOPSIS 
+# GHDL for Windows - GHDL compile script
+# Use 'compile.ps1 -Help' to see the integrated help page
+# 
+# .EXAMPLE
+# C:\PS> .\compile.ps1 -Clean -Compile
+# 
 [CmdletBinding()]
-Param(
-	# compile ALL
-	[switch]$All =			$false,
+param(
+	# Display this help"
+	[switch]$Help =			$false,
 	
-	# compile main targets
-	[switch]$Compile =	$false,
-		# compile GHDL (simulator)
-		[switch]$GHDL =		$false,
-		[switch]$Test =		$false,
+	# Slean up all files and directories
+	[switch]$Clean =					$false,
+		[switch]$Clean_GHDL =		$false,
 	
-	# compile TOOLS
-	[switch]$Tools =		$false,
-		# compile Filter (helper)
-		[switch]$Filter =	$false,
+	# Compile all targets
+	[switch]$All =						$false,
 	
-	# build options
+	# Compile main targets
+	[switch]$Compile =				$false,
+		# Compile GHDL (simulator)
+		[switch]$Compile_GHDL =	$false,
+	# Undocumented
+	[switch]$Test =						$false,
+		# Undocumented
+		[switch]$Test_GHDL =		$false,
+	
+	# Build options
+	# Build a release version
 	[switch]$Release =	$false,
+	# Set the back-end
+	[string]$Backend =	"mcode",
 	
-	# clean up all files and directories
-	[switch]$Clean =		$false,
-	
-	# display this help"
-	[switch]$Help =			$false
+	# Reduced messages
+	[switch]$Quiet =						$false,
+	# Skip warning messages. (Show errors only.)
+	[switch]$SuppressWarnings = $false,
+	# Halt on errors
+	[switch]$HaltOnError =			$false,
+	# Undocumented
+	[switch]$Hosted =						$false
 )
 
 # configure script here
-$Script_RelPathToRoot =	"..\..\.."
+$RelPathToRoot =			"..\..\.."
 
-# save parameters and current working directory
-$Script_Parameters =	$args
+# ---------------------------------------------
+# save parameters and working directory
+$Script_ScriptDir =		$PSScriptRoot
 $Script_WorkingDir =	Get-Location
-$GHDLRootDir =				Convert-Path (Resolve-Path ($PSScriptRoot + "\" + $Script_RelPathToRoot))
+$GHDLRootDir =				Convert-Path (Resolve-Path ($PSScriptRoot + "\" + $RelPathToRoot))
 
 # set default values
-$Script_ExitCode = 		0
-$BuildRelease =				"Development"		# "Release"
+$EnableVerbose =	$PSCmdlet.MyInvocation.BoundParameters["Verbose"].IsPresent
+$EnableDebug =		$PSCmdlet.MyInvocation.BoundParameters["Debug"].IsPresent
 
+# Write-Host ("--> " + $Verbose + " value: " +$PSCmdlet.MyInvocation.BoundParameters["Verbose"] + " IsPresent: " + $PSCmdlet.MyInvocation.BoundParameters["Verbose"].IsPresent)
+# Write-Host ("--> " + $PSCommandPath + "  " + $PSBoundParameters + "  " + $PSCmdlet + "  " + $PSDefaultParameterValues)
+
+# load modules from GHDL's 'libraries' directory
+Import-Module $PSScriptRoot\shared.psm1 -Verbose:$false -ArgumentList "$Script_WorkingDir"
+Import-Module $PSScriptRoot\targets.psm1 -Verbose:$false
+
+# Display help if no command was selected
+$Help = $Help -or (-not (
+					$All -or 
+					$Clean -or $Clean_GHDL -or
+					$Compile -or $Compile_GHDL -or
+					$Test -or $Test_GHDL
+				))
+
+if (-not $Hosted)
+{	Write-Host "================================================================================" -ForegroundColor Magenta
+	Write-Host "GHDL for Windows - GHDL compile script" -ForegroundColor Magenta
+	Write-Host "================================================================================" -ForegroundColor Magenta
+}
+
+if ($Help)
+{	Get-Help $MYINVOCATION.InvocationName -Detailed
+	Exit-CompileScript
+}
+
+if ($Clean)
+{	$Clean_GHDL =		$true
+}
 if ($All)
-{	$Compile =	$true
-	$Tools =		$true
+{	$Compile =			$true
 }
 if ($Compile)
-{	$GHDL =			$true
-	$Test =			$true
+{	$Compile_GHDL =	$true
 }
-if ($Tools)
-{	$Filter =		$true
+if ($Test)
+{	$Test_GHDL =		$true
 }
 
-if ($Release)
-{	$BuildRelease =		"Release"			}
-else
-{	$BuildRelease =		"Development"	}
+# configure some variables: paths, executables, directory names, ...
+$BuildDirectoryName =						"build"
 
-$NoCommand = -not ($Clean -or $All -or $Compile -or $Tools -or $GHDL -or $Test -or $Filter)
-if ($NoCommand)
-{	$Help = $true		}
+# Parameter checks
+if ($Backend -ne "mcode")
+{	Write-Host "[ERROR]: Back-end '$Backend' is not supported on Windows." -ForegroundColor Red
+	Exit-CompileScript -1
+}
 
-Write-Host "================================================================================" -ForegroundColor Magenta
-Write-Host "GHDL for Windows - GHDL and tools compile script" -ForegroundColor Magenta
-Write-Host "================================================================================" -ForegroundColor Magenta
-
-# if command is help or no command was given => display help page(s)
-if ($Help)
-{	Write-Host "Usage:"
-	Write-Host "  compile.ps1 (-Help|-Clean|-All|-Compile|-Tools|-GHDL|-Test|-Filter)" -ForegroundColor Gray
-	Write-Host
-	Write-Host "Options:"
-	Write-Host "  -Release    build in release mode"
-	# Write-Host "  -Debug      enable debug messages"
-	# Write-Host
-	Write-Host "Commands:"
-	Write-Host "  -Help       display this help"
-	Write-Host "  -All        compile all targets"
-	Write-Host "  -Compile    compile all main targets"
-	Write-Host "  -Tools      compile all tool targets"
-	Write-Host "  -GHDL       compile ghdl.exe"
-	Write-Host "  -Filter     compile filter.exe"
-	Write-Host "  -Clean      clean up all files and directories"
-	Write-Host
-	
-	exit 0
-}	# Help
-
-# load modules
-Import-Module $PSScriptRoot\shared.psm1
-Import-Module $PSScriptRoot\targets.psm1
+# construct directories
+$BinaryDestinationDirectory =		"$GHDLRootDir\$BuildDirectoryName\$Backend"
+# construct executables
+$GHDLNewExecutable =						"$GHDLRootDir\$BuildDirectoryName\$Backend\bin\ghdl.exe"
 
 # grep GHDL version string from Ada source file
-$GHDLVersion = 				Get-GHDLVersion $GHDLRootDir
+$GHDLVersion = 							Get-GHDLVersion $GHDLRootDir
+# compute some variables
+$BuildRelease = if ($Release)	{	"Release"	}	else	{	"Development"	}
+if (-not $Hosted)
+{	Write-Host "  Version:    $GHDLVersion"
+	Write-Host "  Release:    $BuildRelease"
+}
 
-# gather git information
 $Git_IsGitRepo =						Test-GitRepository
+# gather git information
 if ($Git_IsGitRepo)
 {	$Git_Branch_Name =				& git rev-parse --abbrev-ref HEAD
-	$Git_Commit_DataString =	& git log -1 --format=%cd --date=short
+	$Git_Commit_DateString =	& git log -1 --format=%cd --date=short
 	$Git_Commit_ShortHash =		& git rev-parse --short HEAD
-}
 
-Write-Host "  Version:    $GHDLVersion"
-Write-Host "  Release:    $BuildRelease"
-if ($Git_IsGitRepo)
-{	Write-Host "  Git branch: $Git_Branch_Name"
-	Write-Host "  Git commit: $Git_Commit_DataString ($Git_Commit_ShortHash)"
+	if (-not $Hosted)
+	{	Write-Host "  Git branch: $Git_Branch_Name"
+		Write-Host "  Git commit: $Git_Commit_DataString ($Git_Commit_ShortHash)"
+	}
 }
-Write-Host
+if (-not $Hosted)
+{	Write-Host ""	}
 
-function Write-TargetResult($error)
-{	if ($error)
-	{	Write-Host "  [FAILED]"	-ForegroundColor Red		}
-	# else
-	# {	Write-Host "  [DONE]"		-ForegroundColor Green	}
-}
-
-if ($BuildRelease -eq "Release")
-{	$BuildDir =		$GHDLRootDir + "\dist\mcode\build"		}
-elseif ($BuildRelease -eq "Development")
-{	$BuildDir =		$GHDLRootDir + "\dist\mcode\build"		}
+if ($Release)
+{	$BuildDirectory =		$BinaryDestinationDirectory		}
 else
-{	Write-Host "[ERROR]: Unknown build setting '$BuildRelease'." -ForegroundColor Red
-	exit 1
-}
+{	$BuildDirectory =		$BinaryDestinationDirectory		}
+
 
 # ==============================================================================
 # Main Target: Clean
 # ==============================================================================
-if ($Clean)
-{	$error = Invoke-Clean $BuildDir
-	Write-TargetResult $error
+if ($Clean_GHDL)
+{	$error = Invoke-Clean $BuildDirectory -Quiet:$Quiet -Verbose:$EnableVerbose -Debug:$EnableDebug
+	if ($error -eq $true)
+	{	Write-Host "  [FAILED]"	-ForegroundColor Red
+		Exit-CompileScript -1
+	}
 }	# Clean
 
 
 # ==============================================================================
 # Main Target: GHDL
 # ==============================================================================
-if ($GHDL)
+if ($Compile_GHDL)
 {	# create a build directory
-	$error = Invoke-CreateBuildDirectory $BuildDir
-	Write-TargetResult $error
+	$error = New-BuildDirectory $BuildDirectory
+	if ($error -eq $true)
+	{	Write-Host "  [FAILED]"	-ForegroundColor Red
+		Exit-CompileScript -1
+	}
 	
 	# patch the version file if it's no release build
-	if ((-not $error) -and ($BuildRelease -eq "Development") -and $Git_IsGitRepo)
-	{	$error = Invoke-PatchVersionFile $GHDLRootDir $Git_Branch_Name $Git_Commit_DataString $Git_Commit_ShortHash
-		Write-TargetResult $error
+	if (-not $Release -and $Git_IsGitRepo)
+	{	$error = Invoke-PatchVersionFile $GHDLRootDir $Git_Branch_Name $Git_Commit_DateString $Git_Commit_ShortHash
+		if ($error -eq $true)
+		{	Write-Host "  [FAILED]"	-ForegroundColor Red
+			Exit-CompileScript -1
+		}
 	}
 	
 	# build C source files
-	if (-not $error)
-	{	$error = Invoke-CompileCFiles $GHDLRootDir $BuildDir
-		Write-TargetResult $error
+	$error = Invoke-CompileCFiles $GHDLRootDir $BinaryDestinationDirectory
+	if ($error -eq $true)
+	{	Write-Host "  [FAILED]"	-ForegroundColor Red
+		Exit-CompileScript -1
 	}
 	
 	# build Ada source files
-	if (-not $error)
-	{	$error = Invoke-CompileGHDLAdaFiles $GHDLRootDir $BuildDir
-		Write-TargetResult $error
+	$error = Invoke-CompileGHDLAdaFiles $GHDLRootDir $BinaryDestinationDirectory
+	if ($error -eq $true)
+	{	Write-Host "  [FAILED]"	-ForegroundColor Red
+		Exit-CompileScript -1
 	}
 	
 	# strip result
-	if (-not $error)
-	{	$error = Invoke-StripGHDLExecutable $BuildDir
-		Write-TargetResult $error
+	$error = Invoke-StripGHDLExecutable $BinaryDestinationDirectory
+	if ($error -eq $true)
+	{	Write-Host "  [FAILED]"	-ForegroundColor Red
+		Exit-CompileScript -1
 	}
 	
 	# restore the version file if it was patched
-	if ((-not $error) -and ($BuildRelease -eq "Development") -and $Git_IsGitRepo)
+	if (-not $Release -and $Git_IsGitRepo)
 	{	$error = Restore-PatchedVersionFile $GHDLRootDir
-		Write-TargetResult $error
+		if ($error -eq $true)
+		{	Write-Host "  [FAILED]"	-ForegroundColor Red
+			Exit-CompileScript -1
+		}
 	}
-} # Compile
+}
 
-if ($Test)
+
+# ==============================================================================
+# Main Target: GHDL
+# ==============================================================================
+if ($Test_GHDL)
 {	# running ghdl
 	$error = Test-GHDLVersion $BuildDir
-	Write-TargetResult $error
+	if ($error -eq $true)
+	{	Write-Host "  [FAILED]"	-ForegroundColor Red
+		Exit-CompileScript -1
+	}
 }	# Test
 
-# ==============================================================================
-# Tool Target: Filter
-# ==============================================================================
-if ($Filter)
-{	# create a build directory
-	$error = Invoke-CreateBuildDirectory $BuildDir
-	Write-TargetResult $error
-
-	# build Ada source files
-	if (-not $error)
-	{	$error = Invoke-CompileFilterAdaFiles $GHDLRootDir $BuildDir
-		Write-TargetResult $error
-	}
-}	# Tools
-
-
-# unload PowerShell modules
-Remove-Module shared
-Remove-Module targets
-	
-# restore working directory if changed
-Set-Location $Script_WorkingDir
-
-# return exit status
-exit $Script_ExitCode
+Exit-CompileScript 0

--- a/dist/mcode/windows/shared.psm1
+++ b/dist/mcode/windows/shared.psm1
@@ -56,7 +56,8 @@ function Exit-CompileScript
 	cd $Module_WorkingDir
 	
 	# unload modules
-	Remove-Module shared
+	Remove-Module shared -Verbose:$false
+	Remove-Module targets -Verbose:$false
 	
 	exit $ExitCode
 }

--- a/dist/mcode/windows/targets.psm1
+++ b/dist/mcode/windows/targets.psm1
@@ -36,20 +36,17 @@
 #		- program version
 
 # configure compiler tools
-$GCCExecutable =					"gcc.exe"
-$GNATMakeExecutable =			"gnatmake.exe"
-$StripExecutable =				"strip.exe"
+$Prog_GCC =								"gcc.exe"
+$Prog_GNATMake =					"gnatmake.exe"
+$Prog_Strip =							"strip.exe"
 
 # configure output file
-$GHDLExecutableName =			"ghdl.exe"
-$FilterExecutable =				"filter.exe"
+$GHDL_Mcode_Name =				"ghdl.exe"
 
 # configure directory structure
 $CommonSourceDirName =		"src"
 $WinMcodeSourceDirName =	"dist\mcode\windows"
 # $WinLLVMSourceDirName =		"dist\llvm\windows"
-$WinMcodeBuildDirName =		"dist\mcode\build"
-# $WinLLVMBuildDirName =		"dist\llvm\build"
 
 # construct file paths
 $VersionFileName =				"version.ads"
@@ -70,17 +67,23 @@ function Invoke-Clean
 		[switch]	$Quiet = $false
 	)
 	
-	Write-Host "Executing build target 'Clean' ..." -ForegroundColor Yellow
-	if ($Quiet -eq $false)
-	{	Write-Host "  Removing all created files and directories..."
-		Write-Host "    rmdir $BuildDirectory"
-	}
-	Remove-Item $BuildDirectory -Force -Recurse -ErrorAction SilentlyContinue
+	$EnableDebug =		-not $Quiet -and (									$PSCmdlet.MyInvocation.BoundParameters["Debug"])
+	$EnableVerbose =	-not $Quiet -and ($EnableDebug	-or $PSCmdlet.MyInvocation.BoundParameters["Verbose"])
 	
+	-not $Quiet			-and (Write-Host "Executing build target 'Clean' ..." -ForegroundColor Yellow)	| Out-Null
+	$EnableVerbose	-and (Write-Host "  Removing all created files and directories..."						)	| Out-Null
+	if (Test-Path -Path $BuildDirectory)
+	{	$EnableDebug		-and (Write-Host "    rmdir $BuildDirectory"																	)	| Out-Null
+		Remove-Item $BuildDirectory -Force -Recurse -ErrorAction SilentlyContinue
+		if ($? -eq $false)
+		{	Write-Host "[ERROR]: Cannot remove '$BuildDirectory'." -ForegroundColor Red
+			return $true
+		}
+	}
 	return $false
 }	# Invoke-Clean
 
-function Invoke-CreateBuildDirectory
+function New-BuildDirectory
 {	<#
 		.SYNOPSIS
 		This CommandLet creates a build directory if not existent, yet.
@@ -95,20 +98,20 @@ function Invoke-CreateBuildDirectory
 		[switch]	$Quiet = $false
 	)
 	
-	Write-Host "Executing build target 'CreateBuildDirectory' ..." -ForegroundColor Yellow
-	if (Test-Path -Path $BuildDirectory)
-	{	if ($Quiet -eq $false)
-		{	Write-Host "  Directory '$BuildDirectory' already exists."		}
-	}
+	Write-Host "Executing build target 'BuildDirectory' ..." -ForegroundColor Yellow
+	if (Test-Path -Path $BuildDirectory -PathType Container)
+	{	-not $Quiet -and (Write-Host "  Directory '$BuildDirectory' already exists."	) 	| Out-Null	}
 	else
-	{	if ($Quiet -eq $false)
-		{	Write-Host "  Creating new directory '$BuildDirectory'."		}
-		
-		[void](New-Item -ItemType directory -Path $BuildDirectory -ErrorAction SilentlyContinue)
+	{	-not $Quiet -and (Write-Host "  Creating new directory '$BuildDirectory'."		) 	| Out-Null
+		New-Item -ItemType Directory -Path $BuildDirectory -ErrorAction SilentlyContinue	| Out-Null
+		if ($? -eq $false)
+		{	Write-Host "[ERROR]: Cannot create '$BuildDirectory'." -ForegroundColor Red
+			return $true
+		}
 	}
 	
 	return $false
-}	# Invoke-CreateBuildDirectory
+}	# New-BuildDirectory
 
 function Get-GHDLVersion
 {	<#
@@ -123,20 +126,20 @@ function Get-GHDLVersion
 	)
 	# construct DirectoryPaths
 	$SourceDirectory =		$GHDLRootDir + "\" + $CommonSourceDirName
-	# construct FilePaths
 	$VersionFilePath =		$SourceDirectory + "\" + $VersionFileName
 	
-	if (-not (Test-Path -Path $VersionFilePath))
-	{	Write-Host "  Version file '$VersionFilePath' does not exists." -ForegroundColor Red
-		return ""
+	if (-not (Test-Path -Path $VersionFilePath -PathType Leaf))
+	{	Write-Host "[ERROR]: Version file '$VersionFilePath' does not exists." -ForegroundColor Red
+		return $true
 	}
 	$FileContent = Get-Content -Path $VersionFilePath
 	foreach ($Line in $FileContent)
 	{	if ($Line -match 'Ghdl_Ver(.+?)\"(.+?)\";')
 		{ return $Matches[2]	}
 	}
-	return ""
-}
+	Write-Host "[ERROR]: RegExp didn't match in '$VersionFilePath'." -ForegroundColor Red
+	return $true
+}	# Get-GHDLVersion
 
 function Invoke-PatchVersionFile
 {	<#
@@ -156,30 +159,36 @@ function Invoke-PatchVersionFile
 	[CmdletBinding()]
 	param(
 		[string]	$GHDLRootDir,
-		[string]	$GitBranchName = "unknown",
-		[string]	$GitCommitDataString = "unknown",
-		[string]	$GitCommitHash = "........",
-		[switch]	$Quiet = $false
+		[string]	$GitBranchName =				"unknown",
+		[string]	$GitCommitDataString =	"unknown",
+		[string]	$GitCommitHash =				"........",
+		[switch]	$Quiet =								$false
 	)
 	# construct DirectoryPaths
 	$SourceDirectory =					$GHDLRootDir + "\" + $CommonSourceDirName
-	# construct FilePaths
 	$CurrentVersionFilePath =		$SourceDirectory + "\" + $VersionFileName
 	$OriginalVersionFilePath =	$SourceDirectory + "\" + $VersionFileName + ".bak"
 	
 	Write-Host "Executing build target 'PatchVersionFile' ..." -ForegroundColor Yellow
 	
-	if (-not (Test-Path -Path $CurrentVersionFilePath))
-	{	Write-Host "  Version file '$CurrentVersionFilePath' does not exists." -ForegroundColor Red
+	if (-not (Test-Path -Path $CurrentVersionFilePath -PathType Leaf))
+	{	Write-Host "[ERROR]: Version file '$CurrentVersionFilePath' does not exists." -ForegroundColor Red
 		return $true
 	}
-	if ($Quiet -eq $false)
-	{	Write-Host "  Patching '$CurrentVersionFilePath'."		}
+	-not $Quiet -and (Write-Host "  Patching '$CurrentVersionFilePath'.") | Out-Null
 	$FileContent = Get-Content -Path $CurrentVersionFilePath -Encoding Ascii
+	if ($? -eq $false)
+	{	Write-Host "[ERROR]: While opening '$CurrentVersionFilePath'." -ForegroundColor Red
+		return $true
+	}
 	$FileContent = $FileContent -Replace "\s\(\d+\)\s", " (commit: $GitCommitDataString;  git branch: $GitBranchName';  hash: $GitCommitHash) "
 	
 	Move-Item $CurrentVersionFilePath $OriginalVersionFilePath -Force
 	$FileContent | Out-File $CurrentVersionFilePath -Encoding Ascii
+	if ($? -eq $false)
+	{	Write-Host "[ERROR]: While writing to '$CurrentVersionFilePath'." -ForegroundColor Red
+		return $true
+	}
 	
 	return $false
 }	# Invoke-PatchVersionFile
@@ -200,19 +209,22 @@ function Restore-PatchedVersionFile
 	)
 	# construct DirectoryPaths
 	$SourceDirectory =					$GHDLRootDir + "\" + $CommonSourceDirName
-	# construct FilePaths
 	$CurrentVersionFilePath =		$SourceDirectory + "\" + $VersionFileName
 	$OriginalVersionFilePath =	$SourceDirectory + "\" + $VersionFileName + ".bak"
 	
 	Write-Host "Executing build target 'PatchedVersionFile' ..." -ForegroundColor Yellow
 	
-	if (-not (Test-Path -Path "$CurrentVersionFilePath"))
-	{	Write-Host "  Version file '$CurrentVersionFilePath' does not exists." -ForegroundColor Red
+	if (-not (Test-Path -Path "$OriginalVersionFilePath" -PathType Leaf))
+	{	Write-Host "[ERROR]: Original version file '$OriginalVersionFilePath' does not exists." -ForegroundColor Red
 		return $true
 	}
-	if ($Quiet -eq $false)
-	{	Write-Host "  Restoring '$CurrentVersionFilePath'."		}
+	-not $Quiet -and (Write-Host "  Restoring '$CurrentVersionFilePath'.") | Out-Null
 	Move-Item $OriginalVersionFilePath $CurrentVersionFilePath -Force
+	if ($? -eq $false)
+	{	Write-Host "[ERROR]: While moving '$OriginalVersionFilePath' to '$CurrentVersionFilePath'." -ForegroundColor Red
+		return $true
+	}
+	
 	return $false
 }	# Restore-PatchedVersionFile
 
@@ -267,13 +279,15 @@ function Invoke-CompileCFiles
 		$Parameters += $SourceDirectory + "\" + $SourceFile.File
 		
 		# call C compiler
-		$InvokeExpr = "$GCCExecutable " + ($Parameters -join " ") + " 2>&1"
+		$InvokeExpr = "$Prog_GCC " + ($Parameters -join " ") + " 2>&1"
 		
 		Write-Host ("  compiling: " + $SourceFile.File)
 		Write-Debug	"    call: $InvokeExpr"
 		$ErrorRecordFound = Invoke-Expression $InvokeExpr | Restore-NativeCommandStream | Write-ColoredGCCLine -Indent "    "
 		if ($LastExitCode -ne 0)
-		{	return $true		}
+		{	Write-Host ("[ERROR]: While compiling '{0}'." -f $SourceFile.File) -ForegroundColor Red
+			return $true
+		}
 	}
 	
 	return $false
@@ -324,7 +338,7 @@ function Invoke-CompileGHDLAdaFiles
 
 	# add output filename
 	$Parameters += '-o'
-	$Parameters += $GHDLExecutableName
+	$Parameters += $GHDL_Mcode_Name
 
 	# append linker parameters
 	$Parameters += '-largs'
@@ -338,59 +352,18 @@ function Invoke-CompileGHDLAdaFiles
 	# $Parameters += '-Wl,--stack,8404992'
 
 	# call Ada compiler (GNAT)
-	$InvokeExpr = "$GNATMakeExecutable " + ($Parameters -join " ") + " 2>&1"
+	$InvokeExpr = "$Prog_GNATMake " + ($Parameters -join " ") + " 2>&1"
 	
 	Write-Host "  compiling with GNAT"
 	Write-Debug "    call: $InvokeExpr"
 	$ErrorRecordFound = Invoke-Expression $InvokeExpr | Restore-NativeCommandStream | Write-ColoredGCCLine -Indent "    "
-	return ($LastExitCode -ne 0)
+	if ($LastExitCode -ne 0)
+	{	Write-Host "[ERROR]: While compiling '$GHDL_Mcode_Name'." -ForegroundColor Red
+		return $true
+	}
+	return $false
 }	# Invoke-CompileGHDLAdaFiles
 
-function Invoke-CompileFilterAdaFiles
-{	<#
-		.SYNOPSIS
-		This CommandLet compiles all Ada files with GNAT.
-		.PARAMETER SourceDirectory
-		The directory where all source files are located.
-		.PARAMETER BuildDirectory
-		The directory where all generated files are stored.
-		.PARAMETER Quiet
-		Disable outputs to the host console
-	#>
-	[CmdletBinding()]
-	param(
-		[string]	$GHDLRootDir,
-		[string]	$BuildDirectory,
-		[switch]	$Quiet = $false
-	)
-	# construct DirectoryPaths
-	$SourceDirectory =					$GHDLRootDir + "\" + $CommonSourceDirName
-	
-	Set-Location $BuildDirectory
-	Write-Host "Executing build target 'CompileFilterAdaFiles' ..." -ForegroundColor Yellow
-	
-	$Parameters = @()
-	$Parameters += Get-CFlags								# append common CFlags
-	$Parameters += '-gnatn'
-
-	# append all source paths
-	$Parameters += '-aI' + $SourceDirectory + '\..\dist\mcode\windows'
-	
-	# top level
-	$Parameters += 'ghdlfilter'
-
-	# add output filename
-	$Parameters += '-o'
-	$Parameters += $FilterExecutable
-
-	# call Ada compiler (GNAT)
-	$InvokeExpr = "$GNATMakeExecutable " + ($Parameters -join " ") + " 2>&1"
-	
-	Write-Host "  compiling with GNAT"
-	Write-Debug "    call: $InvokeExpr"
-	$ErrorRecordFound = Invoke-Expression $InvokeExpr | Restore-NativeCommandStream | Write-ColoredGCCLine -Indent "    "
-	return ($LastExitCode -ne 0)
-}	# Invoke-CompileFilterAdaFiles
 
 function Invoke-StripGHDLExecutable
 {	<#
@@ -411,10 +384,14 @@ function Invoke-StripGHDLExecutable
 	Write-Host "Executing build target 'StripGHDLExecutable' ..." -ForegroundColor Yellow
 	
 	# call striping tool (strip)
-	Write-Host "  stripping '$GHDLExecutableName'"
-	Write-Debug "    call: $StripExecutable $GHDLExecutableName"
-	& $StripExecutable $GHDLExecutableName
-	return ($LastExitCode -ne 0)
+	Write-Host "  stripping '$GHDL_Mcode_Name'"
+	Write-Debug "    call: $Prog_Strip $GHDL_Mcode_Name"
+	& $Prog_Strip $GHDL_Mcode_Name
+	if ($LastExitCode -ne 0)
+	{	Write-Host "[ERROR]: While stripping '$GHDL_Mcode_Name'." -ForegroundColor Red
+		return $true
+	}
+	return $false
 }	# Invoke-StripGHDLExecutable
 
 function Test-GHDLVersion
@@ -435,31 +412,34 @@ function Test-GHDLVersion
 	Set-Location $BuildDirectory
 	Write-Host "Executing build target 'GHDLVersion' ..." -ForegroundColor Yellow
 	
-	if (-not (Test-Path -Path $GHDLExecutableName))
-	{	Write-Host "  GHDL executable '$GHDLExecutableName' does not exists." -ForegroundColor Red
+	if (-not (Test-Path -Path $GHDL_Mcode_Name -PathType Leaf))
+	{	Write-Host "  GHDL executable '$GHDL_Mcode_Name' does not exists." -ForegroundColor Red
 		return $true
 	}
 	
 	# call ghdl
-	$InvokeExpr = "$GHDLExecutableName --version 2>&1"
+	$InvokeExpr = "$GHDL_Mcode_Name --version 2>&1"
 	
-	Write-Host "  executing '$GHDLExecutableName'"
+	Write-Host "  executing '$GHDL_Mcode_Name'"
 	Write-Host "    call: $InvokeExpr"
 	Write-Host "    ----------------------------------------"
 	Invoke-Expression $InvokeExpr | Restore-NativeCommandStream | Write-HostExtended "    "
 	Write-Host "    ----------------------------------------"
-	return ($LastExitCode -ne 0)
+	if ($LastExitCode -ne 0)
+	{	Write-Host "[ERROR]: While executing '$GHDL_Mcode_Name'." -ForegroundColor Red
+		return $true
+	}
+	return $false
 }	# Test-GHDLVersion
 
 
 # export functions
 Export-ModuleMember -Function 'Get-GHDLVersion'
 Export-ModuleMember -Function 'Invoke-Clean'
-Export-ModuleMember -Function 'Invoke-CreateBuildDirectory'
+Export-ModuleMember -Function 'New-BuildDirectory'
 Export-ModuleMember -Function 'Invoke-PatchVersionFile'
 Export-ModuleMember -Function 'Restore-PatchedVersionFile'
 Export-ModuleMember -Function 'Invoke-CompileCFiles'
 Export-ModuleMember -Function 'Invoke-CompileGHDLAdaFiles'
-Export-ModuleMember -Function 'Invoke-CompileFilterAdaFiles'
 Export-ModuleMember -Function 'Invoke-StripGHDLExecutable'
 Export-ModuleMember -Function 'Test-GHDLVersion'

--- a/libraries/vendors/compile-altera.ps1
+++ b/libraries/vendors/compile-altera.ps1
@@ -103,8 +103,8 @@ param(
 $WorkingDir =		Get-Location
 
 # load modules from GHDL's 'vendors' library directory
-Import-Module $PSScriptRoot\config.psm1 -ArgumentList "AlteraQuartus"
-Import-Module $PSScriptRoot\shared.psm1 -ArgumentList @("Altera Quartus", "$WorkingDir")
+Import-Module $PSScriptRoot\config.psm1 -Verbose:$false -ArgumentList "AlteraQuartus"
+Import-Module $PSScriptRoot\shared.psm1 -Verbose:$false -ArgumentList @("Altera Quartus", "$WorkingDir")
 
 # Display help if no command was selected
 $Help = $Help -or (-not ($All -or $Altera -or $Max -or $Cyclone -or $Arria -or $Stratix -or $Nanometer))

--- a/libraries/vendors/compile-lattice.ps1
+++ b/libraries/vendors/compile-lattice.ps1
@@ -114,8 +114,8 @@ param(
 $WorkingDir =		Get-Location
 
 # load modules from GHDL's 'vendors' library directory
-Import-Module $PSScriptRoot\config.psm1 -ArgumentList "LatticeDiamond"
-Import-Module $PSScriptRoot\shared.psm1 -ArgumentList @("Lattice Diamond", "$WorkingDir")
+Import-Module $PSScriptRoot\config.psm1 -Verbose:$false -ArgumentList "LatticeDiamond"
+Import-Module $PSScriptRoot\shared.psm1 -Verbose:$false -ArgumentList @("Lattice Diamond", "$WorkingDir")
 
 # Display help if no command was selected
 $Help = $Help -or (-not ($All -or 

--- a/libraries/vendors/compile-osvvm.ps1
+++ b/libraries/vendors/compile-osvvm.ps1
@@ -72,8 +72,8 @@ param(
 $WorkingDir =		Get-Location
 
 # load modules from GHDL's 'vendors' library directory
-Import-Module $PSScriptRoot\config.psm1 -ArgumentList "OSVVM"
-Import-Module $PSScriptRoot\shared.psm1 -ArgumentList @("OSVVM", "$WorkingDir")
+Import-Module $PSScriptRoot\config.psm1 -Verbose:$false -ArgumentList "OSVVM"
+Import-Module $PSScriptRoot\shared.psm1 -Verbose:$false -ArgumentList @("OSVVM", "$WorkingDir")
 
 # Display help if no command was selected
 $Help = $Help -or (-not ($All -or $OSVVM))

--- a/libraries/vendors/compile-vunit.ps1
+++ b/libraries/vendors/compile-vunit.ps1
@@ -72,8 +72,8 @@ param(
 $WorkingDir =		Get-Location
 
 # load modules from GHDL's 'vendors' library directory
-Import-Module $PSScriptRoot\config.psm1 -ArgumentList "VUnit"
-Import-Module $PSScriptRoot\shared.psm1 -ArgumentList @("VUnit", "$WorkingDir")
+Import-Module $PSScriptRoot\config.psm1 -Verbose:$false -ArgumentList "VUnit"
+Import-Module $PSScriptRoot\shared.psm1 -Verbose:$false -ArgumentList @("VUnit", "$WorkingDir")
 
 # Display help if no command was selected
 $Help = $Help -or (-not ($All -or $VUnit))

--- a/libraries/vendors/compile-xilinx-ise.ps1
+++ b/libraries/vendors/compile-xilinx-ise.ps1
@@ -95,8 +95,8 @@ if ($Help)
 $WorkingDir =		Get-Location
 
 # load modules from GHDL's 'vendors' library directory
-Import-Module $PSScriptRoot\config.psm1 -ArgumentList "XilinxISE"
-Import-Module $PSScriptRoot\shared.psm1 -ArgumentList @("Xilinx ISE", "$WorkingDir")
+Import-Module $PSScriptRoot\config.psm1 -Verbose:$false -ArgumentList "XilinxISE"
+Import-Module $PSScriptRoot\shared.psm1 -Verbose:$false -ArgumentList @("Xilinx ISE", "$WorkingDir")
 
 # Display help if no command was selected
 $Help = $Help -or (-not ($All -or $Unisim -or $Simprim -or $Unimacro))

--- a/libraries/vendors/compile-xilinx-vivado.ps1
+++ b/libraries/vendors/compile-xilinx-vivado.ps1
@@ -86,8 +86,8 @@ param(
 $WorkingDir =		Get-Location
 
 # load modules from GHDL's 'vendors' library directory
-Import-Module $PSScriptRoot\config.psm1 -ArgumentList "XilinxVivado"
-Import-Module $PSScriptRoot\shared.psm1 -ArgumentList @("Xilinx Vivado", "$WorkingDir")
+Import-Module $PSScriptRoot\config.psm1 -Verbose:$false -ArgumentList "XilinxVivado"
+Import-Module $PSScriptRoot\shared.psm1 -Verbose:$false -ArgumentList @("Xilinx Vivado", "$WorkingDir")
 
 # Display help if no command was selected
 $Help = $Help -or (-not ($All -or $Unisim -or $Simprim -or $Unimacro))

--- a/libraries/vendors/shared.psm1
+++ b/libraries/vendors/shared.psm1
@@ -3,10 +3,10 @@
 # kate: tab-width 2; replace-tabs off; indent-width 2;
 # 
 # ==============================================================================
+#	Authors:						Patrick Lehmann
+# 
 #	PowerShell Module:	The module provides common CmdLets for the library
 #											pre-compilation process.
-# 
-#	Authors:						Patrick Lehmann
 # 
 # Description:
 # ------------------------------------
@@ -60,8 +60,8 @@ function Exit-CompileScript
 	cd $Module_WorkingDir
 	
 	# unload modules
-	Remove-Module config
-	Remove-Module shared
+	Remove-Module config -Verbose:$false
+	Remove-Module shared -Verbose:$false
 	
 	if ($ExitCode -eq 0)
 	{	exit 0	}
@@ -201,7 +201,7 @@ function Get-VHDLVariables
 	elseif ($VHDL2008)
 	{	$VHDLVersion =	"v08"
 		$VHDLStandard = "08"
-		$VHDLFlavor =		"standard"
+		$VHDLFlavor =		"synopsys"
 	}
 	else
 	{	$VHDLVersion =	"v93"
@@ -275,8 +275,9 @@ function Start-PackageCompilation
 	Write-Host "Compiling library '$Library' ..." -ForegroundColor Yellow
 	$ErrorCount = 0
 	foreach ($File in $SourceFiles)
-	{	Write-Host "Analyzing package file '$File'" -ForegroundColor Cyan
+	{	Write-Host "Analyzing package file '$File'" -ForegroundColor DarkCyan
 		$InvokeExpr = "$GHDLBinary " + ($GHDLOptions -join " ") + " --work=$Library " + $File + " 2>&1"
+		# Write-Host "  $InvokeExpr" -ForegroundColor DarkGray
 		$ErrorRecordFound = Invoke-Expression $InvokeExpr | Restore-NativeCommandStream | Write-ColoredGHDLLine $SuppressWarnings
 		if ($LastExitCode -ne 0)
 		{	$ErrorCount += 1
@@ -325,8 +326,9 @@ function Start-PrimitiveCompilation
 	Write-Host "Compiling library '$Library' ..." -ForegroundColor Yellow
 	$ErrorCount = 0
 	foreach ($File in $SourceFiles)
-	{	Write-Host "Analyzing primitive file '$File'" -ForegroundColor Cyan
+	{	Write-Host "Analyzing primitive file '$File'" -ForegroundColor DarkCyan
 		$InvokeExpr = "$GHDLBinary " + ($GHDLOptions -join " ") + " --work=$Library " + $File + " 2>&1"
+		# Write-Host "  $InvokeExpr" -ForegroundColor DarkGray
 		$ErrorRecordFound = Invoke-Expression $InvokeExpr | Restore-NativeCommandStream | Write-ColoredGHDLLine $SuppressWarnings
 		if ($LastExitCode -ne 0)
 		{	$ErrorCount += 1


### PR DESCRIPTION
Hello,

here are the latest reworks for the Windows compile flow with PowerShell.
**This commit changes:**
- Removed `-InstallPath <Path>` -> `-Install [<Path>]` is enough
- Uses internal help pages like the user compile scripts
- Steps can be run as a group e.g. `-Compile` or as single tasks, e.g. `-Clean_GHDL -Compile_GHDL`
- Improved error reporting
- `filter.exe` is no longer needed and build on Windows  
  It got replaced by PowerShell commands and act like the original `sed` commands in `Makefile`.
- The zip-file is created with a version number and back-end name. (`-CreatePackage -Zip`)

**Known issues:**
- Some lines are printed in verbose mode, even if `-Verbose` is disabled
- Installing GHDL in `PATH` is broken -> disabled  
  I need to rewrite the functions for setting/removing paths
- Local `README.md` needs updates.