### PR TITLE
Fix synopsys V08 library that was missing std_logic_1164-body.o.

### DIFF
--- a/libraries/Makefile.inc
+++ b/libraries/Makefile.inc
@@ -296,7 +296,7 @@ synopsys.v08: $(ANALYZE_DEP) $(LIB08_DIR) $(SYNOPSYS08_SRCS) ieee.v08 force
 	cd $(SYN08_DIR); \
 	$(CP) ../ieee/ieee-obj08.cf .; \
 	test x$(VHDLLIBS_COPY_OBJS) = "xno" || \
-	for i in $(IEEE_SRCS) $(MATH_SRCS) $(VITAL2000_SRCS); do \
+	for i in $(IEEE08_SRCS) $(VITAL2000_SRCS); do \
 	  b=`basename $$i .vhdl`; \
 	  if [ -f ../ieee/$$b.o ]; then \
 	    $(LN) ../ieee/$$b.o $$b.o || exit 1; \


### PR DESCRIPTION
The objects from IEEE_SRCS were looked while
objects from IEEE08_SRCS were built.

Signed-off-by: David Keller <david.keller@enyx.fr>