### PR TITLE
Simplifying build instructions for GCC backend

### DIFF
--- a/BUILD.txt
+++ b/BUILD.txt
@@ -59,19 +59,12 @@ $ ./configure --with-gcc=/path/to/gcc/source/dir --prefix=/usr/local
 Then invoke make to copy ghdl sources in the source dir:
 $ make copy-sources
 
-To build gcc, you must first compile gmp, mpfr and mpc (replace /usr/local
- by your prefix directory):
-$ mkdir gmp-objs; cd gmp-objs
-$ ../gmp-4.3.2/configure --prefix=/usr/local --disable-shared
-$ make; make install
-$ cd ..; mkdir mpfr-objs; cd mpfr-objs
-$ ../mpfr-2.4.2/configure --prefix=/usr/local --disable-shared \
-  --with-gmp=/usr/local
-$ make; make install
-$ cd ..; mkdir mpc-objs; cd mpc-objs
-$ ../mpc-0.8.1/configure --prefix=/usr/local --disable-shared \
-  --with-gmp=/usr/local
-$ make; make install
+There are some dependencies for building gcc (gmp, mpfr and mpc). If you have
+not them installed on your system, you can either build them manually or use
+the 'download_prerequisite' script provided in gcc source tree (recommended).
+
+$ cd /path/to/gcc/source/dir
+$ ./contrib/download_prerequisites
 
 Then configure gcc.  The list of --disable configure options could be
 adjusted for your needs.  GHDL don't require all these optional


### PR DESCRIPTION
Suggest the use of GCC's download_prerequisites for setting up gmp, mpfr, mpc
directly in the source tree. This is actually GCC's recommended way of
getting them (see https://gcc.gnu.org/wiki/InstallingGCC).