### PR TITLE
Windows Build Flow: Fixed error of premature module unload.

### DIFF
--- a/dist/mcode/winbuild.ps1
+++ b/dist/mcode/winbuild.ps1
@@ -92,12 +92,13 @@ $GHDLRootDir =				Convert-Path (Resolve-Path ($PSScriptRoot + "\" + $RelPathToRo
 # set default values
 $EnableVerbose =			$PSCmdlet.MyInvocation.BoundParameters["Verbose"].IsPresent
 $EnableDebug =				$PSCmdlet.MyInvocation.BoundParameters["Debug"].IsPresent
+$Hosting =						$true
 
 # Write-Host ("--> " + $Verbose + " value: " +$PSCmdlet.MyInvocation.BoundParameters["Verbose"] + " IsPresent: " + $PSCmdlet.MyInvocation.BoundParameters["Verbose"].IsPresent)
 # Write-Host ("--> " + $PSCommandPath + "  " + $PSBoundParameters + "  " + $PSCmdlet + "  " + $PSDefaultParameterValues)
 
 # load modules from GHDL's 'libraries' directory
-Import-Module $PSScriptRoot\windows\shared.psm1 -Verbose:$false -ArgumentList "$Script_WorkingDir"
+Import-Module $PSScriptRoot\windows\shared.psm1  -Verbose:$false -ArgumentList "$Script_WorkingDir", $Hosting
 Import-Module $PSScriptRoot\windows\targets.psm1 -Verbose:$false
 
 # Display help if no command was selected

--- a/dist/mcode/windows/compile-ghdl.ps1
+++ b/dist/mcode/windows/compile-ghdl.ps1
@@ -46,29 +46,29 @@
 [CmdletBinding()]
 param(
 	# Display this help"
-	[switch]$Help =			$false,
+	[switch]$Help =							$false,
 	
 	# Slean up all files and directories
-	[switch]$Clean =					$false,
-		[switch]$Clean_GHDL =		$false,
+	[switch]$Clean =						$false,
+		[switch]$Clean_GHDL =			$false,
 	
 	# Compile all targets
-	[switch]$All =						$false,
+	[switch]$All =							$false,
 	
 	# Compile main targets
-	[switch]$Compile =				$false,
+	[switch]$Compile =					$false,
 		# Compile GHDL (simulator)
-		[switch]$Compile_GHDL =	$false,
+		[switch]$Compile_GHDL =		$false,
 	# Undocumented
-	[switch]$Test =						$false,
+	[switch]$Test =							$false,
 		# Undocumented
-		[switch]$Test_GHDL =		$false,
+		[switch]$Test_GHDL =			$false,
 	
 	# Build options
 	# Build a release version
-	[switch]$Release =	$false,
+	[switch]$Release =					$false,
 	# Set the back-end
-	[string]$Backend =	"mcode",
+	[string]$Backend =					"mcode",
 	
 	# Reduced messages
 	[switch]$Quiet =						$false,
@@ -97,7 +97,7 @@ $EnableDebug =		$PSCmdlet.MyInvocation.BoundParameters["Debug"].IsPresent
 # Write-Host ("--> " + $PSCommandPath + "  " + $PSBoundParameters + "  " + $PSCmdlet + "  " + $PSDefaultParameterValues)
 
 # load modules from GHDL's 'libraries' directory
-Import-Module $PSScriptRoot\shared.psm1 -Verbose:$false -ArgumentList "$Script_WorkingDir"
+Import-Module $PSScriptRoot\shared.psm1  -Verbose:$false -ArgumentList "$Script_WorkingDir", $Hosted
 Import-Module $PSScriptRoot\targets.psm1 -Verbose:$false
 
 # Display help if no command was selected

--- a/dist/mcode/windows/compile-libraries.ps1
+++ b/dist/mcode/windows/compile-libraries.ps1
@@ -91,21 +91,10 @@ $EnableVerbose =			$PSCmdlet.MyInvocation.BoundParameters["Verbose"].IsPresent
 $EnableDebug =				$PSCmdlet.MyInvocation.BoundParameters["Debug"].IsPresent
 
 # load modules from GHDL's 'libraries' directory
-Import-Module $PSScriptRoot\shared.psm1 -Verbose:$false -ArgumentList "$Script_WorkingDir"
+Import-Module $PSScriptRoot\shared.psm1 -Verbose:$false -ArgumentList "$Script_WorkingDir", $Hosted
 
 # Display help if no command was selected
 $Help = $Help -or (-not ($Compile -or $VHDL87 -or $VHDL93 -or $VHDL2008 -or $Clean))
-
-function Exit-CompileScript
-{	[CmdletBinding()]
-	param(
-		[int]$ExitCode = 0
-	)
-	cd $Script_WorkingDir
-	# unload modules
-	Remove-Module shared -Verbose:$false
-	exit $ExitCode
-}
 
 if ($Help)
 {	Get-Help $MYINVOCATION.InvocationName -Detailed

--- a/dist/mcode/windows/shared.psm1
+++ b/dist/mcode/windows/shared.psm1
@@ -32,19 +32,19 @@
 
 [CmdletBinding()]
 param(
-	[Parameter(Mandatory=$true)][string]$WorkingDir
+	[Parameter(Mandatory=$true)][string]$WorkingDir,
+	[Parameter(Mandatory=$true)][Switch]$Hosted
 )
 
-$Module_WorkingDir =			$WorkingDir
+$Module_WorkingDir =	$WorkingDir
+$Module_Hosted =			$Hosted
 
 function Exit-CompileScript
-{		<#
+{	<#
 		.SYNOPSIS
 		Undocumented
-		
 		.DESCRIPTION
 		Undocumented
-		
 		.PARAMETER ExitCode
 		ExitCode of this script run
 	#>
@@ -52,13 +52,12 @@ function Exit-CompileScript
 	param(
 		[int]$ExitCode = 0
 	)
-	
 	cd $Module_WorkingDir
-	
 	# unload modules
-	Remove-Module shared -Verbose:$false
-	Remove-Module targets -Verbose:$false
-	
+	if (-not $Module_Hosted)
+	{	Remove-Module shared  -Verbose:$false
+		Remove-Module targets -Verbose:$false
+	}
 	exit $ExitCode
 }
 


### PR DESCRIPTION
This commit fixes the premature module unloads for `shared` and `targets`.