### PR TITLE
Winbuild: Fixed Windows build flow after makefile changes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ grt.lst
 libgrt.a
 run-bind.adb
 run-bind.ads
+src/version.ads

--- a/dist/mcode/windows/compile-ghdl.ps1
+++ b/dist/mcode/windows/compile-ghdl.ps1
@@ -228,15 +228,6 @@ if ($Compile_GHDL)
 	{	Write-Host "  [FAILED]"	-ForegroundColor Red
 		Exit-CompileScript -1
 	}
-	
-	# restore the version file if it was patched
-	if (-not $Release -and $Git_IsGitRepo)
-	{	$error = Restore-PatchedVersionFile $GHDLRootDir
-		if ($error -eq $true)
-		{	Write-Host "  [FAILED]"	-ForegroundColor Red
-			Exit-CompileScript -1
-		}
-	}
 }
 
 

--- a/dist/mcode/windows/compile-libraries.ps1
+++ b/dist/mcode/windows/compile-libraries.ps1
@@ -187,7 +187,7 @@ if (-not $Hosted)
 }
 
 if ($Clean)
-{	Write-Host "Removing all created files and directories..."
+{	Write-Host "Removing all created files and directories..." -ForegroundColor Yellow
 	if (Test-Path -Path $VHDLDestinationLibraryDirectory)
 	{	$EnableVerbose	-and (Write-Host "  rmdir $VHDLDestinationLibraryDirectory")	| Out-Null
 		Remove-Item $VHDLDestinationLibraryDirectory -Force -Recurse -ErrorAction SilentlyContinue


### PR DESCRIPTION
Hello,

this pull request:

* removes `Restore-PatchedVersionFile`
* adapts `Invoke-PatchVersionFile`
* add `version.ads` to `.gitignore`
* improves output formatting
* GHDL can be installed into PATH at: system, user or session level

This PR fixes issues after 	de1c213c36101c80f961f2ba24d4188646de8cb5.
