### PR TITLE
Added GHDL's version filter pragmas to std_logic_misc.

### DIFF
--- a/dist/windows/compile-libraries.ps1
+++ b/dist/windows/compile-libraries.ps1
@@ -166,13 +166,13 @@ $SourceFiles = @{
 		"prmtvs_p",							"prmtvs_b",
 		"memory_p",							"memory_b"
 	);
-	"synopsys8793" = @(
-		"std_logic_textio"
-	);
 	"synopsys" = @(
 		"std_logic_arith",
 		"std_logic_unsigned",
-		"std_logic_signed",
+		"std_logic_signed"
+	);
+	"synopsys8793" = @(
+		"std_logic_textio",
 		"std_logic_misc",				"std_logic_misc-body"
 	);
 	"mentor" = @(

--- a/dist/windows/shared.psm1
+++ b/dist/windows/shared.psm1
@@ -106,20 +106,20 @@ function Format-VHDLSourceFile
 	)
 	
 	begin
-	{	$State = 0
-		$VersionAsInt = switch ($Version)
-										{	"87"	{	87	}
-											"93"	{	93	}
-											"02"	{	2		}
-											"08"	{	8		}
-										}
+	{	$State = 1
+		$Version = switch ($Version)
+								{	"87"	{	87	}
+									"93"	{	93	}
+									"02"	{	2		}
+									"08"	{	8		}
+								}
 	}
 	
 	process
 	{	if ($InputObject -is [String])
 		{	$Line = $InputObject.ToString()
 			if ($Line.StartsWith("--START-V"))
-			{	$State =	switch ($Line.Substring(9, 2))
+			{	$State = switch ($Line.Substring(9, 2))
 									{	"87"	{	87	}
 										"93"	{	93	}
 										"02"	{	2		}
@@ -128,21 +128,19 @@ function Format-VHDLSourceFile
 			}
 			elseif ($Line.StartsWith("--START-!V"))
 			{	if ($Line.Substring(10, 2) -eq $Version)
-				{	$State = -1	}
+				{	$State = 2	}
 			}
 			elseif ($Line.StartsWith("--END-V") -or $Line.StartsWith("--END-!V"))
-			{	$State = 0		}
+			{	$State = 1		}
 			else
-			{	if ($State -eq 0)
+			{	if ($State -eq 1)
 				{	if ($Line.EndsWith("--V$Version"))
 					{	Write-Output $Line		}
 					elseif (-not (($Line -like "*--V??") -or ($Line.EndsWith("--!V$Version"))))
 					{	Write-Output $Line		}
 				}
-				elseif ($State -eq $VersionAsInt)
+				elseif ($State -eq $Version)
 				{	Write-Output $Line			}
-				# else
-				# {	Write-Host "Discard line: $Line" -ForegroundColor Red	}
 			}
 		}
 		else


### PR DESCRIPTION
Hello Tristan,

**this PR changes:**
* Added GHDL's version filter pragmas to std_logic_misc.
  * Disable overloaded functions for `std_logic_vector` and their bodies.
    * Drive
    * Sense
    * AND_REDUCE
    * NAND_REDUCE
    * OR_REDUCE
    * NOR_REDUCE
    * XOR_REDUCE
    * XNOR_REDUCE
* Added `std_logic_misc` for all VHDL versions to the synopsys flavor.
* Fixed an issue in Format-VHDLSourceFile.
* Changed source file sets in `Makefile.inc`

**This PR doesn't fix entirely:**
* Makefile.inc
  * A `sed` filter for `!V08` and `START-!V08` is missing
  * I can not really see when and where to apply the sed rules to create the filtered files before analyze
  
So please do the needed changes for Makefile.inc and sed before merging. The Windows compile flow is already changed and working. If completed, this issue will fix issue #180.

Kind regards
    Patrick Lehmann