### PR TITLE
Win32.c quickfix for mingw64 llvm.

### DIFF
--- a/src/grt/config/win32.c
+++ b/src/grt/config/win32.c
@@ -164,6 +164,7 @@ int
 __ghdl_run_through_longjump (int (*func)(void))
 {
   int res;
+#ifdef __i386__
   struct exception_registration er;
   struct exception_registration *prev;
 
@@ -186,6 +187,13 @@ __ghdl_run_through_longjump (int (*func)(void))
   /* Restore.  */
   asm ("mov %0,%%fs:(0)" : : "r" (prev));
 
+#elif defined (__x86_64__)
+  run_env_en = 1;
+  res = setjmp (run_env);
+  if (res == 0)
+    res = (*func)();
+  run_env_en = 0;
+#endif
   return res;
 }
 


### PR DESCRIPTION
This commit applies a quickfix for win32.c for MinGW64 with LLVM backend.