### PR TITLE
Added OSVVM's new Scoreboards to the file list in compile-osvvm.ps1/sh.

### DIFF
--- a/libraries/vendors/compile-osvvm.ps1
+++ b/libraries/vendors/compile-osvvm.ps1
@@ -141,6 +141,9 @@ if ((-not $StopCompiling) -and $OSVVM)
 		"RandomBasePkg.vhd",
 		"RandomPkg.vhd",
 		"CoveragePkg.vhd",
+		"ScoreboardGenericPkg.vhd",
+		"ScoreboardPkg_int.vhd",
+		"ScoreboardPkg_slv.vhd",
 		"OsvvmContext.vhd"
 	)
 	$SourceFiles = $Files | % { "$SourceDirectory\$_" }

--- a/libraries/vendors/compile-osvvm.sh
+++ b/libraries/vendors/compile-osvvm.sh
@@ -202,6 +202,9 @@ if [ "$COMPILE_OSVVM" == "TRUE" ]; then
 		RandomBasePkg.vhd
 		RandomPkg.vhd
 		CoveragePkg.vhd
+		ScoreboardGenericPkg.vhd
+		ScoreboardPkg_int.vhd
+		ScoreboardPkg_slv.vhd
 		OsvvmContext.vhd
 	)
 


### PR DESCRIPTION
**This pull request:**
* Updates compile-osvvm.ps1/sh to add [OSVVM's](https://github.com/JimLewis/OSVVM) new [scoreboard](https://github.com/JimLewis/OSVVM/blob/master/ScoreboardGenericPkg.vhd?ts=2) packages.

-----------------------
:warning: The Scoreboard instance package for an [integer based scoreboard](https://github.com/JimLewis/OSVVM/blob/master/ScoreboardPkg_int.vhd?ts=2) causes an internal error reported as issue #197 .