### PR TITLE
Bugfixes for compile-xilinx-***.sh scripts.

### DIFF
--- a/libraries/vendors/compile-xilinx-ise.sh
+++ b/libraries/vendors/compile-xilinx-ise.sh
@@ -276,7 +276,10 @@ fi
 # compile unisim primitives
 if [ $STOPCOMPILING -eq 0 ] && [ "$COMPILE_UNISIM" == "TRUE" ]; then
 	Library="unisim"
-	SourceFiles="$(LC_COLLATE=C ls $SourceDirectory/${Library}s/primitive/*.vhd)"
+	SourceFiles=()
+	while IFS= read -r File; do
+		SourceFiles+=("$SourceDirectory/${Library}s/primitive/$File")
+	done < <(grep --no-filename -R '^[a-zA-Z]' "$SourceDirectory/${Library}s/primitive/vhdl_analyze_order")
 
 	GHDLCompileLibrary
 fi
@@ -284,7 +287,10 @@ fi
 # compile unisim secureip primitives
 if [ $STOPCOMPILING -eq 0 ] && [ "$COMPILE_UNISIM" == "TRUE" ] && [ "$COMPILE_SECUREIP" == "TRUE" ]; then
 	Library="secureip"
-	SourceFiles="$(LC_COLLATE=C ls $SourceDirectory/unisims/$Library/*.vhd)"
+	SourceFiles=()
+	while IFS= read -r File; do
+		SourceFiles+=("$SourceDirectory/unisims/$Library/$File")
+	done < <(grep --no-filename -R '^[a-zA-Z]' "$SourceDirectory/unisims/$Library/vhdl_analyze_order")
 
 	GHDLCompileLibrary
 fi
@@ -309,7 +315,7 @@ fi
 # compile unimacro macros
 if [ $STOPCOMPILING -eq 0 ] && [ "$COMPILE_UNIMACRO" == "TRUE" ]; then
 	Library="unimacro"
-	SourceFiles="$(LC_COLLATE=C ls $SourceDirectory/$Library/*_MACRO.vhd)"
+	SourceFiles=($(LC_COLLATE=C ls $SourceDirectory/$Library/*_MACRO.vhd))
 
 	GHDLCompileLibrary
 fi
@@ -335,7 +341,10 @@ fi
 # compile simprim primitives
 if [ $STOPCOMPILING -eq 0 ] && [ "$COMPILE_SIMPRIM" == "TRUE" ]; then
 	Library="simprim"
-	SourceFiles="$(LC_COLLATE=C ls $SourceDirectory/${Library}s/primitive/other/*.vhd)"
+	SourceFiles=()
+	while IFS= read -r File; do
+		SourceFiles+=("$SourceDirectory/${Library}s/primitive/other/$File")
+	done < <(grep --no-filename -R '^[a-zA-Z]' "$SourceDirectory/${Library}s/primitive/other/vhdl_analyze_order")
 
 	GHDLCompileLibrary
 fi
@@ -343,7 +352,10 @@ fi
 # compile simprim secureip primitives
 if [ $STOPCOMPILING -eq 0 ] && [ "$COMPILE_SIMPRIM" == "TRUE" ] && [ "$COMPILE_SECUREIP" == "TRUE" ]; then
 	Library="secureip"
-	SourceFiles="$(LC_COLLATE=C ls $SourceDirectory/simprims/$Library/other/*.vhd)"
+	SourceFiles=()
+	while IFS= read -r File; do
+		SourceFiles+=("$SourceDirectory/simprims/$Library/other/$File")
+	done < <(grep --no-filename -R '^[a-zA-Z]' "$SourceDirectory/simprims/$Library/other/vhdl_analyze_order")
 
 	GHDLCompileLibrary
 fi

--- a/libraries/vendors/compile-xilinx-vivado.sh
+++ b/libraries/vendors/compile-xilinx-vivado.sh
@@ -76,6 +76,10 @@ while [[ $# > 0 ]]; do
 		COMPILE_UNIMACRO=TRUE
 		NO_COMMAND=0
 		;;
+		--unifast)
+		COMPILE_UNIFAST=TRUE
+		NO_COMMAND=0
+		;;
 		--secureip)
 		COMPILE_SECUREIP=TRUE
 		;;
@@ -146,6 +150,7 @@ if [ "$HELP" == "TRUE" ]; then
 	echo "  -a --all              Compile all Xilinx simulation libraries."
 	echo "     --unisim           Compile the unisim library."
 	echo "     --unimacro         Compile the unimacro library."
+	echo "     --unifast          Compile the unifast library."
 	echo "     --secureip         Compile the secureip library."
 	echo ""
 	echo "Library compile options:"
@@ -169,6 +174,7 @@ fi
 if [ "$COMPILE_ALL" == "TRUE" ]; then
 	COMPILE_UNISIM=TRUE
 	COMPILE_UNIMACRO=TRUE
+	COMPILE_UNIFAST=TRUE
 	COMPILE_SECUREIP=TRUE
 fi
 
@@ -266,7 +272,10 @@ fi
 # compile unisim primitives
 if [ $STOPCOMPILING -eq 0 ] && [ "$COMPILE_UNISIM" == "TRUE" ]; then
 	Library="unisim"
-	SourceFiles="$(LC_COLLATE=C ls $SourceDirectory/${Library}s/primitive/*.vhd)"
+	SourceFiles=()
+	while IFS= read -r File; do
+		SourceFiles+=("$SourceDirectory/${Library}s/primitive/$File")
+	done < <(grep --no-filename -R '^[a-zA-Z]' "$SourceDirectory/${Library}s/primitive/vhdl_analyze_order")
 
 	GHDLCompileLibrary
 fi
@@ -307,14 +316,26 @@ fi
 # compile unimacro macros
 if [ $STOPCOMPILING -eq 0 ] && [ "$COMPILE_UNIMACRO" == "TRUE" ]; then
 	Library="unimacro"
-	SourceFiles="$(LC_COLLATE=C ls $SourceDirectory/$Library/*_MACRO.vhd)"
+	SourceFiles=()
+	while IFS= read -r File; do
+		SourceFiles+=("$SourceDirectory/${Library}/$File")
+	done < <(grep --no-filename -R '^[a-zA-Z]' "$SourceDirectory/${Library}/vhdl_analyze_order")
 
 	GHDLCompileLibrary
 fi
 
 # Library UNIFAST
 # ==============================================================================
-# TODO:
+# compile unisim primitives
+if [ $STOPCOMPILING -eq 0 ] && [ "$COMPILE_UNIFAST" == "TRUE" ]; then
+	Library="unifast"
+	SourceFiles=()
+	while IFS= read -r File; do
+		SourceFiles+=("$SourceDirectory/${Library}/primitive/$File")
+	done < <(grep --no-filename -R '^[a-zA-Z]' "$SourceDirectory/${Library}/primitive/vhdl_analyze_order")
+
+	GHDLCompileLibrary
+fi
 
 echo "--------------------------------------------------------------------------------"
 echo -n "Compiling Xilinx Vivado libraries "


### PR DESCRIPTION
This pull request:
- Fixes a bug introduced by falsely using Bash syntax.
- If a `vhdl_analyze_order` file is provided, the scripts will use them now instead of `ls .../*.vhd` commands.
- Adds support for the unifast library in `compile-xilinx-vivado.sh`.