### PR TITLE
Updated compile order in compile-osvvm.* files.

### DIFF
--- a/dist/mcode/windows/compile-libraries.ps1
+++ b/dist/mcode/windows/compile-libraries.ps1
@@ -361,7 +361,7 @@ if ($VHDL87)
 		}
 	}
 	
-	foreach ($SourceFile in $SourceFiles["synopsys"] + $SourceFiles["synopsys8793"])
+	foreach ($SourceFile in $SourceFiles[$VHDLFlavor] + $SourceFiles["synopsys8793"])
 	{	Write-Host "    file: v$VHDLVersion\$SourceFile.v$VHDLVersion"
 		$EnableVerbose -and	(Write-Host "      Patching file for VHDL-$VHDLVersion"																																														) | Out-Null
 		$EnableDebug -and		(Write-Host "        Get-Content `"$VHDLSourceLibraryDirectory\$VHDLSourcesIndex\$SourceFile.vhdl`" -Encoding Ascii ``"	-ForegroundColor DarkGray	) | Out-Null

--- a/libraries/vendors/compile-osvvm.ps1
+++ b/libraries/vendors/compile-osvvm.ps1
@@ -72,23 +72,19 @@ param(
 $WorkingDir =		Get-Location
 
 # set default values
-$EnableVerbose =			$PSCmdlet.MyInvocation.BoundParameters["Verbose"]
-$EnableDebug =				$PSCmdlet.MyInvocation.BoundParameters["Debug"]
-if ($EnableVerbose -eq $null)	{	$EnableVerbose =	$false	}
-if ($EnableDebug	 -eq $null)	{	$EnableDebug =		$false	}
-if ($EnableDebug	 -eq $true)	{	$EnableVerbose =	$true		}
+$EnableDebug =		[bool]$PSCmdlet.MyInvocation.BoundParameters["Debug"]
+$EnableVerbose =	[bool]$PSCmdlet.MyInvocation.BoundParameters["Verbose"] -or $EnableDebug
 
 # load modules from GHDL's 'vendors' library directory
 Import-Module $PSScriptRoot\config.psm1 -Verbose:$false -Debug:$false -ArgumentList "OSVVM"
 Import-Module $PSScriptRoot\shared.psm1 -Verbose:$false -Debug:$false -ArgumentList @("OSVVM", "$WorkingDir")
 
 # Display help if no command was selected
-$Help = $Help -or (-not ($All -or $OSVVM -or $Clean))
-
-if ($Help)
+if ($Help -or (-not ($All -or $OSVVM -or $Clean)))
 {	Get-Help $MYINVOCATION.InvocationName -Detailed
 	Exit-CompileScript
 }
+
 if ($All)
 {	$OSVVM =			$true
 }
@@ -132,18 +128,21 @@ if ((-not $StopCompiling) -and $OSVVM)
 	$Files = @(
 		"NamePkg.vhd",
 		"OsvvmGlobalPkg.vhd",
-		"TextUtilPkg.vhd",
+		"VendorCovApiPkg.vhd",
 		"TranscriptPkg.vhd",
+		"TextUtilPkg.vhd",
 		"AlertLogPkg.vhd",
-		"MemoryPkg.vhd",
 		"MessagePkg.vhd",
 		"SortListPkg_int.vhd",
 		"RandomBasePkg.vhd",
 		"RandomPkg.vhd",
 		"CoveragePkg.vhd",
+		"MemoryPkg.vhd",
 		"ScoreboardGenericPkg.vhd",
-		"ScoreboardPkg_int.vhd",
 		"ScoreboardPkg_slv.vhd",
+		"ScoreboardPkg_int.vhd",
+		"ResolutionPkg.vhd",
+		"TbUtilPkg.vhd",
 		"OsvvmContext.vhd"
 	)
 	$SourceFiles = $Files | % { "$SourceDirectory\$_" }

--- a/libraries/vendors/compile-osvvm.sh
+++ b/libraries/vendors/compile-osvvm.sh
@@ -193,18 +193,21 @@ if [ "$COMPILE_OSVVM" == "TRUE" ]; then
 	Files=(
 		NamePkg.vhd
 		OsvvmGlobalPkg.vhd
-		TextUtilPkg.vhd
+		VendorCovApiPkg.vhd
 		TranscriptPkg.vhd
+		TextUtilPkg.vhd
 		AlertLogPkg.vhd
-		MemoryPkg.vhd
 		MessagePkg.vhd
 		SortListPkg_int.vhd
 		RandomBasePkg.vhd
 		RandomPkg.vhd
 		CoveragePkg.vhd
+		MemoryPkg.vhd
 		ScoreboardGenericPkg.vhd
-		ScoreboardPkg_int.vhd
 		ScoreboardPkg_slv.vhd
+		ScoreboardPkg_int.vhd
+		ResolutionPkg.vhd
+		TbUtilPkg.vhd
 		OsvvmContext.vhd
 	)
 


### PR DESCRIPTION
@JimLewis released [OSVVM 2016.11](https://github.com/OSVVM/OSVVM/tree/2016.11?ts=2). It comes with new VHDL 2008 packages. So the compile order needs an update. The next release or an intermediate release will contain a `compiler_order` file as used by e.g. Xilinx. With this file, both pre-compile scripts will be independent of file list and ordering changes.

**This pull request changes:**

* Updated compile order and file list for OSVVM pre-compilation scripts.


---------------
**Related issues:**
* OSVVM
  * [Can OSVVM provide a "vhdl_analyze_order" file?](https://github.com/OSVVM/OSVVM/issues/19?ts=2)