### PR TITLE
removing PSL coverage hit default report

### DIFF
--- a/src/vhdl/translate/trans-chap9.adb
+++ b/src/vhdl/translate/trans-chap9.adb
@@ -549,8 +549,10 @@ package body Trans.Chap9 is
                Chap8.Translate_Report
                  (Stmt, Ghdl_Psl_Assert_Failed, Severity_Level_Error);
             when Iir_Kind_Psl_Cover_Statement =>
-               Chap8.Translate_Report
-                 (Stmt, Ghdl_Psl_Cover, Severity_Level_Note);
+               if Get_Report_Expression (Stmt) /= Null_Iir then
+                  Chap8.Translate_Report
+                     (Stmt, Ghdl_Psl_Cover, Severity_Level_Note);
+               end if;
             when others =>
                Error_Kind ("Translate_Psl_Directive_Statement", Stmt);
          end case;

--- a/testsuite/gna/issue228/tb.vhdl
+++ b/testsuite/gna/issue228/tb.vhdl
@@ -1,0 +1,61 @@
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity foo is
+  port (
+    clk : in std_ulogic;
+    a0 : in std_ulogic
+  );
+end entity;
+
+architecture bar of foo is
+begin
+  -- psl default clock is rising_edge(clk);
+  -- psl sequence rising_a0 is {not(a0); a0};
+  -- psl sequence falling_a0 is {a0; not(a0)};
+  -- psl cover {rising_a0};
+  -- psl cover {falling_a0} report "falling_a0 custom report";
+end architecture;
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity foo_tb is
+end entity;
+
+architecture tb of foo_tb is
+  signal clk : std_ulogic := '0';
+  signal a0 : std_ulogic;
+begin
+
+  clk_gen:
+    process
+    begin
+      for i in 0 to 10 loop
+        clk <= not(clk);
+        wait for 10 ns;
+      end loop;
+      wait;
+    end process;
+
+  test_driver:
+    process
+    begin
+      a0 <= '1';
+      wait until rising_edge(clk);
+      a0 <= '0';
+      wait until rising_edge(clk);
+      a0 <= '1';
+      wait until rising_edge(clk);
+      wait until rising_edge(clk);
+      wait;
+    end process;
+
+  dut:
+    entity work.foo(bar)
+    port map (
+      clk => clk,
+      a0 => a0);
+
+end architecture;

--- a/testsuite/gna/issue228/testsuite.sh
+++ b/testsuite/gna/issue228/testsuite.sh
@@ -1,0 +1,15 @@
+#! /bin/sh
+
+. ../../testenv.sh
+
+GHDL_STD_FLAGS=-fpsl
+analyze tb.vhdl
+elab_simulate foo_tb 2>sim_log.txt
+
+run "grep -q 'falling_a0 custom report' sim_log.txt"
+run_failure "grep -q 'sequence covered' sim_log.txt"
+
+rm -f sim_log.txt
+clean
+
+echo "Test successful"


### PR DESCRIPTION
It closes #228.

Nothing is displayed unless the user specifies a report statement.
Testcase added to check this behaviour.