### PR TITLE
Allow not to pass `$BLD` as argument to <travis-ci.sh>

### DIFF
--- a/dist/travis-ci.sh
+++ b/dist/travis-ci.sh
@@ -5,7 +5,8 @@
 set -e
 
 CDIR=$PWD
-BLD=$1
+
+if [ $# -ne 0 ]; then BLD=$1; fi
 
 # Display environment
 echo "Environment:"
@@ -58,7 +59,7 @@ echo "creating $PKG_FILE"
 tar -zcvf $PKG_FILE -C $prefix .
 
 # Test
-export GHDL="$CDIR/install-$1/bin/ghdl"
+export GHDL="$CDIR/install-$BLD/bin/ghdl"
 cd testsuite
 gnatmake get_entities
 ./testsuite.sh


### PR DESCRIPTION
The proposed modification behaves equally if an argument is passed. However, it does not overwrite `$BLD` if no argument is passed, so that it can be previously defined.
In fact, it is previously defined in the three builds declared in the [.travis.yml](https://github.com/tgingold/ghdl/blob/master/.travis.yml).