### PR TITLE
target install.libghdlsynth added

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -312,6 +312,8 @@ libghdlsynth.a: $(GRT_ADD_OBJS) $(GRT_SRC_DEPS) version.ads force
 libghdlsynth$(SOEXT): $(GRT_ADD_SHOBJS) $(GRT_SRC_DEPS) version.ads force
 	$(GNATMAKE) -I- -aI. -D pic -z libghdlsynth -o $@ $(GNATFLAGS) $(PIC_FLAGS) -gnat12 $(GHDL_SYNTHLIB_INCFLAGS) -bargs -shared -Llibghdlsynth_ -largs -shared $(GRT_ADD_SHOBJS) $(SHLIB_FLAGS)
 
+install.libghdlsynth: install.libghdlsynth.include install.libghdlsynth.static install.libghdlsynth.shared
+
 install.libghdlsynth.include: install.dirs
 	$(INSTALL_DATA) -p $(srcdir)/src/synth/ghdlsynth.h $(DESTDIR)$(incdir)/
 	$(INSTALL_DATA) -p $(srcdir)/src/synth/ghdlsynth_gates.h $(DESTDIR)$(incdir)/


### PR DESCRIPTION
The target **install.libghdlsynth** was missing in the Makefile file, so the command make install.libghdlsynth did not work when following the instructions for building ghdlsynth