### PR TITLE
Avoid problems from not using quotes in shell script.

### DIFF
--- a/dist/travis-ci.sh
+++ b/dist/travis-ci.sh
@@ -4,9 +4,9 @@
 # Stop in case of error
 set -e
 
-CDIR=$PWD
+CDIR=$(pwd)
 
-if [ $# -ne 0 ]; then BLD=$1; fi
+if [ $# -ne 0 ]; then BLD="$1"; fi
 
 # Display environment
 echo "Environment:"
@@ -15,8 +15,8 @@ env
 # Prepare
 prefix="$CDIR/install-$BLD"
 mkdir "$prefix"
-mkdir build-$BLD
-cd build-$BLD
+mkdir "build-$BLD"
+cd "build-$BLD"
 
 # Configure
 case "$BLD" in
@@ -52,11 +52,11 @@ PKG_VER=`grep Ghdl_Ver src/version.in | sed -e 's/.*"\(.*\)";/\1/'`
 if [ "$TRAVIS_TAG" = "" ]; then
     PKG_TAG=`date -u +%Y%m%d`
 else
-    PKG_TAG=$TRAVIS_TAG
+    PKG_TAG="$TRAVIS_TAG"
 fi
-PKG_FILE=ghdl-$PKG_VER-$BLD-$PKG_TAG.tgz
+PKG_FILE="ghdl-$PKG_VER-$BLD-$PKG_TAG.tgz"
 echo "creating $PKG_FILE"
-tar -zcvf $PKG_FILE -C $prefix .
+tar -zcvf "$PKG_FILE" -C "$prefix" .
 
 # Test
 export GHDL="$CDIR/install-$BLD/bin/ghdl"


### PR DESCRIPTION
While developing #272 I had to add quotes to line `PKG_FILE="ghdl-$PKG_VER-$BLD-$PKG_TAG.tgz"`. Without them, the tarball generated in the container was `ghdl--mcode-20170210.tgz` ([see](https://api.travis-ci.org/jobs/200292577/log.txt?deansi=true)). Just in case, I added a few more.