### PR TITLE
Extract tag declarations from <travis-ci.sh>. Rename it to <buildtest…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,9 @@ matrix:
         apt:
           packages:
           - gnat
-script: ./dist/travis-ci.sh $BLD
+script:
+ - . ./dist/travis-ci.sh
+ - ./dist/buildtest.sh -b $BLD -f $PKG_FILE
 deploy:
   provider: releases
   skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ matrix:
           - gnat
 script:
  - . ./dist/travis-ci.sh
- - ./dist/buildtest.sh -b $BLD -f $PKG_FILE
+ - chmod +x ./dist/buildtest.sh && ./dist/buildtest.sh -b $BLD -f $PKG_FILE
 deploy:
   provider: releases
   skip_cleanup: true

--- a/dist/buildtest.sh
+++ b/dist/buildtest.sh
@@ -1,0 +1,65 @@
+#! /bin/sh
+# This script is executed in the travis-ci environment.
+
+# Stop in case of error
+set -e
+
+while getopts ":b:f:" opt; do
+  case $opt in
+    b) BLD=$OPTARG ;;
+	f) PKG_FILE=$OPTARG;;
+    \?) echo "Invalid option: -$OPTARG" >&2; exit 1 ;;
+    :)  echo "Option -$OPTARG requires an argument." >&2; exit 1 ;;
+  esac
+done
+
+CDIR=$(pwd)
+
+# Display environment
+echo "Environment:"
+env
+
+# Prepare
+prefix="$CDIR/install-$BLD"
+mkdir "$prefix"
+mkdir "build-$BLD"
+cd "build-$BLD"
+
+# Configure
+case "$BLD" in
+  mcode)
+      ../configure --prefix="$prefix"
+      MAKEOPTS=""
+      ;;
+
+  llvm-3.5)
+      ../configure --prefix="$prefix" --with-llvm-config=llvm-config-3.5
+      MAKEOPTS="CXX=clang++"
+      ;;
+
+  llvm-3.8)
+      ../configure --prefix="$prefix" --with-llvm-config=llvm-config-3.8
+      MAKEOPTS="CXX=clang++-3.8"
+      ;;
+
+  *)
+      echo "unknown build $BLD"
+      exit 1
+      ;;
+esac
+
+# Build
+make $MAKEOPTS
+make install
+cd ..
+
+# Package
+echo "creating $PKG_FILE"
+tar -zcvf "$PKG_FILE" -C "$prefix" .
+
+# Test
+export GHDL="$CDIR/install-$BLD/bin/ghdl"
+cd testsuite
+gnatmake get_entities
+./testsuite.sh
+cd ..

--- a/dist/travis-ci.sh
+++ b/dist/travis-ci.sh
@@ -1,52 +1,3 @@
-#! /bin/sh
-# This script is executed in the travis-ci environment.
-
-# Stop in case of error
-set -e
-
-CDIR=$(pwd)
-
-if [ $# -ne 0 ]; then BLD="$1"; fi
-
-# Display environment
-echo "Environment:"
-env
-
-# Prepare
-prefix="$CDIR/install-$BLD"
-mkdir "$prefix"
-mkdir "build-$BLD"
-cd "build-$BLD"
-
-# Configure
-case "$BLD" in
-  mcode)
-      ../configure --prefix="$prefix"
-      MAKEOPTS=""
-      ;;
-
-  llvm-3.5)
-      ../configure --prefix="$prefix" --with-llvm-config=llvm-config-3.5
-      MAKEOPTS="CXX=clang++"
-      ;;
-
-  llvm-3.8)
-      ../configure --prefix="$prefix" --with-llvm-config=llvm-config-3.8
-      MAKEOPTS="CXX=clang++-3.8"
-      ;;
-
-  *)
-      echo "unknown build $BLD"
-      exit 1
-      ;;
-esac
-
-# Build
-make $MAKEOPTS
-make install
-cd ..
-
-# Package
 PKG_VER=`grep Ghdl_Ver src/version.in | sed -e 's/.*"\(.*\)";/\1/'`
 
 if [ "$TRAVIS_TAG" = "" ]; then
@@ -54,13 +5,5 @@ if [ "$TRAVIS_TAG" = "" ]; then
 else
     PKG_TAG="$TRAVIS_TAG"
 fi
-PKG_FILE="ghdl-$PKG_VER-$BLD-$PKG_TAG.tgz"
-echo "creating $PKG_FILE"
-tar -zcvf "$PKG_FILE" -C "$prefix" .
 
-# Test
-export GHDL="$CDIR/install-$BLD/bin/ghdl"
-cd testsuite
-gnatmake get_entities
-./testsuite.sh
-cd ..
+export PKG_FILE="ghdl-$PKG_VER-$BLD-$PKG_TAG.tgz"


### PR DESCRIPTION
….sh> and allow to pass -b  ($BLD) and -f ($PKG_FILE) as arguments. Save tags declarations in <travis-ci.sh>, with a different meaning now. Modify <.travis.yml> accordingly.

If $PKG_FILE is to be used in different scripts, it is safer to generate it just once, since it depends on 'date'.