### PR TITLE
Self-extracting PowerShell scripts as an installer alternative.

### DIFF
--- a/dist/windows/InstallerTemplate.ps1
+++ b/dist/windows/InstallerTemplate.ps1
@@ -1,0 +1,312 @@
+# EMACS settings: -*-	tab-width: 2; indent-tabs-mode: t -*-
+# vim: tabstop=2:shiftwidth=2:noexpandtab
+# kate: tab-width 2; replace-tabs off; indent-width 2;
+# 
+# ==============================================================================
+#	Authors:						Patrick Lehmann
+# 
+#	PowerShell Script:	Self-extracting (ZIP) installer for GHDL for Windows
+# 
+# Description:
+# ------------------------------------
+#	This is a PowerShell script (executable) which:
+#		- writes a ZIP file form an internal BLOB variable (base64 encoded)
+#		- extract the ZIP file's content to a destination directory
+#
+# ==============================================================================
+#	Copyright (C) 2015-2017 Patrick Lehmann
+#	
+#	GHDL is free software; you can redistribute it and/or modify it under
+#	the terms of the GNU General Public License as published by the Free
+#	Software Foundation; either version 2, or (at your option) any later
+#	version.
+#	
+#	GHDL is distributed in the hope that it will be useful, but WITHOUT ANY
+#	WARRANTY; without even the implied warranty of MERCHANTABILITY or
+#	FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+#	for more details.
+#	
+#	You should have received a copy of the GNU General Public License
+#	along with GHDL; see the file COPYING.  If not, write to the Free
+#	Software Foundation, 59 Temple Place - Suite 330, Boston, MA
+#	02111-1307, USA.
+# ==============================================================================
+
+# .SYNOPSIS 
+# GHDL for Windows - GHDL installer script
+# Use 'install.ps1 -Help' to see the integrated help page
+# 
+# .EXAMPLE
+# #
+# # Normal flow
+# PS> .\install.ps1 -Install
+# 
+# # Advanced flow
+# PS> .\compile.ps1 -Install "C:\Tools\GHDL"
+#
+[CmdletBinding()]
+Param(
+	# install all files into a directory (xcopy deployment)
+	[switch]$Install = $false,
+	[parameter(mandatory=$false, ValueFromRemainingArguments=$true)]
+	[string]$InstallDir = "",
+	# update files
+	[switch]$Update,
+
+	# display this help"
+	[switch]$Help
+)
+
+# save parameters and current working directory
+$Script_ScriptDir =		$PSScriptRoot
+$Script_WorkingDir =	Get-Location
+$GHDLRootDir =				Convert-Path (Resolve-Path ($PSScriptRoot + "\" + $RelPathToRoot))
+
+# set default values
+$EnableVerbose =			$PSCmdlet.MyInvocation.BoundParameters["Verbose"]
+$EnableDebug =				$PSCmdlet.MyInvocation.BoundParameters["Debug"]
+if ($EnableVerbose -eq $null)	{	$EnableVerbose =	$false	}
+if ($EnableDebug	 -eq $null)	{	$EnableDebug =		$false	}
+if ($EnableDebug	 -eq $true)	{	$EnableVerbose =	$true		}
+
+# Display help if no command was selected
+$Help = $Help -or (-not ($Install -or $Update))
+
+# configure some variables: paths, executables, directory names, ...
+$GHDLVersion =				"0.34-dev"
+$GHDLBackend =				"mcode"
+$DefaultInstallPath =	"C:\Program Files (x86)\GHDL"				# This is the default path for 32-bit applications (x86-32)
+
+Write-Host "================================================================================" -ForegroundColor Magenta
+Write-Host "GHDL for Windows - GHDL install script" -ForegroundColor Magenta
+Write-Host "================================================================================" -ForegroundColor Magenta
+
+if ($Help)
+{	Get-Help $MYINVOCATION.InvocationName -Detailed
+	Exit-CompileScript
+}
+
+$EnvPath_ContainerMapping = @{
+	Machine =	[EnvironmentVariableTarget]::Machine
+	User =		[EnvironmentVariableTarget]::User
+}
+
+function Exit-Script
+{	[CmdletBinding()]
+	param(
+		[int]$ExitCode = 0
+	)
+	cd $Script_WorkingDir
+	exit $ExitCode
+}
+
+# GitHub user:            https://github.com/mkropat
+# Gist account at GitHub: https://gist.github.com/mkropat
+# Gist snippet URL:       https://gist.github.com/mkropat/c1226e0cc2ca941b23a9
+function Add-EnvPath
+{	param(
+		[Parameter(Mandatory=$true)]
+		[string] $Path,
+
+		[ValidateSet("Machine", "User", "Session")]
+		[string] $Container = "Session"
+	)
+
+	if ($Container -ne "Session")
+	{	$containerType =	$EnvPath_ContainerMapping[$Container]
+		$persistedPaths =	[Environment]::GetEnvironmentVariable("Path", $containerType) -split ";"
+		if ($persistedPaths -notcontains $Path)
+		{	$persistedPaths = $persistedPaths + $Path | where { $_ }
+			[Environment]::SetEnvironmentVariable("Path", $persistedPaths -join ";", $containerType)
+		}
+	}
+
+	$envPaths = $env:Path -split ";"
+	if ($envPaths -notcontains $Path)
+	{	$envPaths = $envPaths + $Path | where { $_ }
+		$env:Path = $envPaths -join ";"
+	}
+}
+
+# GitHub user:            https://github.com/mkropat
+# Gist account at GitHub: https://gist.github.com/mkropat
+# Gist snippet URL:       https://gist.github.com/mkropat/c1226e0cc2ca941b23a9
+function Remove-EnvPath
+{	param (
+		[Parameter(Mandatory=$true)]
+		[string] $Path,
+
+		[ValidateSet("Machine", "User", "Session")]
+		[string] $Container = "Session"
+	)
+
+	if ($Container -ne "Session")
+	{	$containerType =	$EnvPath_ContainerMapping[$Container]
+		$persistedPaths =	[Environment]::GetEnvironmentVariable("Path", $containerType) -split ";"
+		if ($persistedPaths -contains $Path)
+		{	$persistedPaths = $persistedPaths | where { $_ -and $_ -ne $Path }
+			[Environment]::SetEnvironmentVariable("Path", $persistedPaths -join ";", $containerType)
+		}
+	}
+
+	$envPaths = $env:Path -split ";"
+	if ($envPaths -contains $Path)
+	{	$envPaths = $envPaths | where { $_ -and $_ -ne $Path }
+		$env:Path = $envPaths -join ";"
+	}
+}
+
+# GitHub user:            https://github.com/mkropat
+# Gist account at GitHub: https://gist.github.com/mkropat
+# Gist snippet URL:       https://gist.github.com/mkropat/c1226e0cc2ca941b23a9
+function Get-EnvPath
+{	param (
+		[Parameter(Mandatory=$true)]
+		[ValidateSet("Machine", "User")]
+		[string] $Container
+	)
+
+	$containerType = $EnvPath_ContainerMapping[$Container]
+	[Environment]::GetEnvironmentVariable('Path', $containerType) -split ";" | where { $_ }
+}
+
+# ============================================================================
+# Base64 encoded zip file content
+# ============================================================================
+
+# DATASECTION
+
+# ============================================================================
+
+
+# ============================================================================
+# Install tasks
+# ============================================================================
+if ($Install)
+{	Write-Host "Installing GHDL $GHDLVersion for Windows..."
+	if ($InstallDir -eq "")
+	{	$InstallPath = $DefaultInstallPath
+	}
+	else
+	{	$InstallPath = $InstallDir			}
+	$InstallPath = $InstallPath.TrimEnd("\")
+	
+	if (Test-Path -Path $InstallPath)
+	{	Write-Host "[ERROR]: Directory '$InstallPath' already exists." -ForegroundColor Red
+		Exit-Script -1
+	}
+	Write-Host "  Install directory: $InstallPath"
+	Write-Host "  Creating directory '$InstallPath' and sub-directories..."
+	New-Item -ItemType Directory -Path "$InstallPath"						-ErrorAction SilentlyContinue	| Out-Null
+
+	# writing ZIP file to disk
+	$TempFilePath =									[System.IO.Path]::GetTempFileName()
+	Write-Host "  Writing temporary ZIP file: $TempFilePath"
+	$CompressedFileContentAsBytes =	[System.Convert]::FromBase64String($CompressedFileContentInBase64)
+	[System.IO.File]::WriteAllBytes("$TempFilePath", $CompressedFileContentAsBytes)
+	
+	Write-Host "  Extracting ZIP file to: $InstallPath"
+	Expand-Archive "$TempFilePath" -OutputPath $InstallPath
+
+	Remove-Item $TempFilePath
+	
+	Write-Host "  Install GHDL in PATH at machine level? [" -NoNewline -ForegroundColor DarkCyan
+	Write-Host "M" -NoNewline -ForegroundColor Cyan
+	Write-Host "achine/" -NoNewline -ForegroundColor DarkCyan
+	Write-Host "u" -NoNewline -ForegroundColor Cyan
+	Write-Host "ser/" -NoNewline -ForegroundColor DarkCyan
+	Write-Host "s" -NoNewline -ForegroundColor Cyan
+	Write-Host "ession/" -NoNewline -ForegroundColor DarkCyan
+	Write-Host "n" -NoNewline -ForegroundColor Cyan
+	Write-Host "o]: " -NoNewline -ForegroundColor DarkCyan
+	$InstallInPath = (Read-Host).ToLower()
+	if (($InstallInPath -eq "") -or ($InstallInPath -eq "m"))
+	{	Write-Host "  Adding GHDL to PATH at machine level."
+		Add-EnvPath -Path "$InstallPath\bin" -Container "Machine"
+		Add-EnvPath -Path "$InstallPath\bin" -Container "Session"
+	}
+	elseif ($InstallInPath -eq "u")
+	{	Write-Host "  Adding GHDL to PATH at user level."
+		Add-EnvPath -Path "$InstallPath\bin" -Container "User"
+		Add-EnvPath -Path "$InstallPath\bin" -Container "Session"
+	}
+	elseif ($InstallInPath -eq "s")
+	{	Write-Host "  Adding GHDL to PATH at session level."
+		Add-EnvPath -Path "$InstallPath\bin" -Container "Session"
+	}
+	
+	Write-Host
+	Write-Host "Installing files " -NoNewline
+	Write-Host "[SUCCESSFUL]" -ForegroundColor Green
+	Write-Host
+	
+	Exit-Script
+}	# Install
+elseif ($Update)
+{	Write-Host "Updating GHDL $GHDLVersion for Windows..."
+	$InstallPath = $InstallDir.TrimEnd("\")
+	
+	Write-Host "  Install directory: $InstallPath"
+	if (Test-Path -Path $InstallPath)
+	{	Write-Host "  Cleaning up installation directory '$InstallPath'." -ForegroundColor Yellow
+		Get-ChildItem -Path $InstallPath -Depth 0 | foreach { Remove-Item $_ -Recurse -ErrorAction SilentlyContinue }
+	}
+	
+	Write-Host "  Removing GHDL from PATH variables in Machine, User, Session ..." -ForegroundColor Yellow
+	foreach ($container in @("Machine", "User"))
+	{	foreach ($entry in (Get-EnvPath -Container $container))
+		{	if ($entry.ToLower().Contains("ghdl"))
+			{	Write-Host "    Removing '$entry' from $container level."
+				Remove-EnvPath -Path $entry -Container $container
+			}
+		}
+	}
+	Remove-EnvPath -Path $entry -Container "Session"
+	
+	Write-Host "  Creating directory sub-directories in '$InstallPath' ..."
+	
+	# writing ZIP file to disk
+	$TempFilePath =									[System.IO.Path]::GetTempFileName()
+	Write-Host "  Writing temporary ZIP file: $TempFilePath"
+	$CompressedFileContentAsBytes =	[System.Convert]::FromBase64String($CompressedFileContentInBase64)
+	[System.IO.File]::WriteAllBytes("$TempFilePath", $CompressedFileContentAsBytes)
+	
+	Write-Host "  Extracting ZIP file to: $InstallPath"
+	Expand-Archive "$TempFilePath" -OutputPath $InstallPath
+
+	Remove-Item $TempFilePath
+
+	Write-Host "  Install GHDL in PATH at machine level? [" -NoNewline -ForegroundColor DarkCyan
+	Write-Host "M" -NoNewline -ForegroundColor Cyan
+	Write-Host "achine/" -NoNewline -ForegroundColor DarkCyan
+	Write-Host "u" -NoNewline -ForegroundColor Cyan
+	Write-Host "ser/" -NoNewline -ForegroundColor DarkCyan
+	Write-Host "s" -NoNewline -ForegroundColor Cyan
+	Write-Host "ession/" -NoNewline -ForegroundColor DarkCyan
+	Write-Host "n" -NoNewline -ForegroundColor Cyan
+	Write-Host "o]: " -NoNewline -ForegroundColor DarkCyan
+	$InstallInPath = (Read-Host).ToLower()
+	if (($InstallInPath -eq "") -or ($InstallInPath -eq "m"))
+	{	Write-Host "  Adding GHDL to PATH at machine level."
+		Add-EnvPath -Path "$InstallPath\bin" -Container "Machine"
+		Add-EnvPath -Path "$InstallPath\bin" -Container "Session"
+	}
+	elseif ($InstallInPath -eq "u")
+	{	Write-Host "  Adding GHDL to PATH at user level."
+		Add-EnvPath -Path "$InstallPath\bin" -Container "User"
+		Add-EnvPath -Path "$InstallPath\bin" -Container "Session"
+	}
+	elseif ($InstallInPath -eq "s")
+	{	Write-Host "  Adding GHDL to PATH at session level."
+		Add-EnvPath -Path "$InstallPath\bin" -Container "Session"
+	}
+	
+	Write-Host
+	Write-Host "Updating files " -NoNewline
+	Write-Host "[SUCCESSFUL]" -ForegroundColor Green
+	Write-Host
+	
+	Exit-Script
+}	# Update
+	
+Exit-Script


### PR DESCRIPTION
Hello,

this pull request:
* Add a new option to `compile.ps1` to create a self-extracting PowerShell script.
  ```
  cd GHDLRoot
  .\dist\windows\compile.ps1 -Clean -Compile
  .\dist\windows\compile.ps1 -Package -Zip
  .\dist\windows\compile.ps1 -Package -PS1
  ```
  (All command can be combined into one call.)
* Adds a template file `InstallerTemplate.ps1` which is used to create the installer.

**How does it work?**

1. Creating the installer:
   1. GHDL is compressed in a ZIP file with preserving directory structure.
   2. The ZIP file is read from disk and base64 encoded (2.2 MiB => 6 MiB)
   3. A prepared template file is filled with the base64 string and saved.
   4. The installer can be deployed (e.g. via GitHub releases)
2. Using the installer:
   1. The user downloads the *.ps1 file.
   2. The user executes `installer.ps1 -Install`.  
      (Note a pure call to `installer.ps1` only displays the embedded help page.)
      * The embedded base64 string is decoded and written to a temporary ZIP file.
      * The content is extracted into the Installation directory.
      * The script asks if it should modify `PATH` (machine, user or session level).
      * The temp. ZIP file is removed.
