### PR TITLE
Add -H to ghwdump to dump full pathnames of signals

### DIFF
--- a/src/grt/ghwdump.c
+++ b/src/grt/ghwdump.c
@@ -34,6 +34,7 @@ usage (void)
   printf ("Options are:\n"
 	  " -t  display types\n"
 	  " -h  display hierarchy\n"
+	  " -H  display hierarchy with full pathnames\n"
 	  " -T  display time\n"
 	  " -s  display signals (and time)\n"
 	  " -f  <lst> list of signals to display (default: all, example: -f 1,3,5-7,21-33)\n"
@@ -133,6 +134,7 @@ main (int argc, char **argv)
   int flag_disp_hierarchy;
   int flag_disp_time;
   int flag_disp_signals;
+  int flag_full_names;
   int flag_list;
   int flag_verbose;
   int nb_signals;
@@ -144,6 +146,7 @@ main (int argc, char **argv)
   progname = argv[0];
   flag_disp_types = 0;
   flag_disp_hierarchy = 0;
+  flag_full_names = 0;
   flag_disp_time = 0;
   flag_disp_signals = 0;
   flag_list = 0;
@@ -156,7 +159,7 @@ main (int argc, char **argv)
     {
       int c;
 
-      c = getopt (argc, argv, "thTslvf:");
+      c = getopt (argc, argv, "thHTslvf:");
       if (c == -1)
 	break;
       switch (c)
@@ -166,6 +169,10 @@ main (int argc, char **argv)
 	  break;
 	case 'h':
 	  flag_disp_hierarchy = 1;
+	  break;
+	case 'H':
+	  flag_disp_hierarchy = 1;
+	  flag_full_names = 1;
 	  break;
 	case 'T':
 	  flag_disp_time = 1;
@@ -252,7 +259,10 @@ main (int argc, char **argv)
 	  if (flag_disp_types)
 	    ghw_disp_types (hp);
 	  if (flag_disp_hierarchy)
-	    ghw_disp_hie (hp, hp->hie);
+	    {
+	      hp->flag_full_names = flag_full_names;
+	      ghw_disp_hie (hp, hp->hie);
+	    }
 
 #if 1
 	  sm = ghw_sm_init;

--- a/src/grt/ghwlib.c
+++ b/src/grt/ghwlib.c
@@ -1042,6 +1042,12 @@ print_name (struct ghw_hie *hie, int full_names)
   for (i = 0; i < depth; ++i)
     {
       printf ("%s%s", i ? "/" : "", buf[i]->name);
+      if (ghw_hie_generate_for == buf[i]->kind)
+	{
+	  putchar ('(');
+	  ghw_disp_value (buf[i]->u.blk.iter_value, buf[i]->u.blk.iter_type);
+	  putchar (')');
+	}
     }
   putchar (':');
   putchar (' ');

--- a/src/grt/ghwlib.c
+++ b/src/grt/ghwlib.c
@@ -1038,9 +1038,10 @@ print_name (struct ghw_hie *hie, int full_names)
     }
 
   putchar (' ');
+  putchar ('/');
   for (i = 0; i < depth; ++i)
     {
-      printf ("%s%s", i ? "." : "", buf[i]->name);
+      printf ("%s%s", i ? "/" : "", buf[i]->name);
     }
   putchar (':');
   putchar (' ');
@@ -1060,8 +1061,9 @@ ghw_disp_hie (struct ghw_handler *h, struct ghw_hie *top)
 
   while (1)
     {
-      for (i = 0; i < indent; i++)
-       fputc (' ', stdout);
+      if (0 == h->flag_full_names)
+	for (i = 0; i < indent; i++)
+	  fputc (' ', stdout);
       printf ("%s", ghw_get_hie_name (hie));
 
       switch (hie->kind)
@@ -1144,7 +1146,6 @@ ghw_read_eoh (struct ghw_handler *h)
 {
   return 0;
 }
-
 
 int
 ghw_read_base (struct ghw_handler *h)

--- a/src/grt/ghwlib.c
+++ b/src/grt/ghwlib.c
@@ -840,6 +840,7 @@ ghw_read_hie (struct ghw_handler *h)
 
   h->nbr_sigs++;
   h->skip_sigs = NULL;
+  h->flag_full_names = 0;
   h->sigs = (struct ghw_sig *) malloc (h->nbr_sigs * sizeof (struct ghw_sig));
   memset (h->sigs, 0, h->nbr_sigs * sizeof (struct ghw_sig));
 
@@ -1004,6 +1005,48 @@ ghw_get_hie_name (struct ghw_hie *h)
 void
 ghw_disp_value (union ghw_val *val, union ghw_type *type);
 
+static void
+print_name (struct ghw_hie *hie, int full_names)
+{
+  int i;
+  int depth;
+  struct ghw_hie *p;
+  struct ghw_hie **buf;
+  struct ghw_hie **end;
+
+  if (0 == full_names)
+    {
+      printf (" %s: ", hie->name);
+      return;
+    }
+
+  p = hie;
+  depth = 0;
+  while (p && p->name)
+    {
+      p = p->parent;
+      ++depth;
+    }
+  buf = (struct ghw_hie **) malloc (depth * sizeof (struct ghw_hie *));
+
+  p = hie;
+  end = depth + buf;
+  while (p && p->name)
+    {
+      *(--end) = p;
+      p = p->parent;
+    }
+
+  putchar (' ');
+  for (i = 0; i < depth; ++i)
+    {
+      printf ("%s%s", i ? "." : "", buf[i]->name);
+    }
+  putchar (':');
+  putchar (' ');
+  free (buf);
+}
+
 void
 ghw_disp_hie (struct ghw_handler *h, struct ghw_hie *top)
 {
@@ -1018,7 +1061,7 @@ ghw_disp_hie (struct ghw_handler *h, struct ghw_hie *top)
   while (1)
     {
       for (i = 0; i < indent; i++)
-	fputc (' ', stdout);
+       fputc (' ', stdout);
       printf ("%s", ghw_get_hie_name (hie));
 
       switch (hie->kind)
@@ -1031,7 +1074,7 @@ ghw_disp_hie (struct ghw_handler *h, struct ghw_hie *top)
 	case ghw_hie_process:
 	case ghw_hie_package:
 	  if (hie->name)
-	    printf (" %s", hie->name);
+	    print_name (hie, h->flag_full_names);
 	  if (hie->kind == ghw_hie_generate_for)
 	    {
 	      printf ("(");
@@ -1057,7 +1100,7 @@ ghw_disp_hie (struct ghw_handler *h, struct ghw_hie *top)
 	    unsigned int *sigs = hie->u.sig.sigs;
 	    unsigned int k, num;
 
-	    printf (" %s: ", hie->name);
+	    print_name (hie, h->flag_full_names);
 	    ghw_disp_subtype_indication (h, hie->u.sig.type);
 	    printf (":");
 	    k = 0;

--- a/src/grt/ghwlib.h
+++ b/src/grt/ghwlib.h
@@ -333,6 +333,7 @@ struct ghw_handler
   /* Non-composite (or basic) signals.  */
   int nbr_sigs;
   char *skip_sigs;
+  int flag_full_names;
   struct ghw_sig *sigs;
 
   /* Hierarchy.  */


### PR DESCRIPTION
Add new switch -H to ghwdump.

This is very similar to -h (dump hierarchy) except that full the signal pathname in the hierarchy is printed instead of just the signal name, and indentation is removed.

This is useful when doing batch processing on a ghw file to figure out the id of a bunch of signals that might not have unique terminal names in the hierarchy.

The pathname is in a format compatible with the file respectively read and written by the --read-wave-opt and --write-wave-opt options of ghdl.

Example current output with -h:

```
ghwdump -h waves.ghw
...
  instance lfsr:
   port-in clk: std_logic: #1
   port-in rst: std_logic: #2
   port-in off: std_logic: #46
   port-in seed: std_logic_vector (31 downto 0): #47-#78
   port-out val: std_logic_vector (31 downto 0): #79-#110
   signal s0: std_logic_vector (31 downto 0): #195-#226
   signal s1: std_logic_vector (31 downto 0): #227-#258
   signal s2: std_logic_vector (31 downto 0): #259-#290
   signal s3: std_logic_vector (31 downto 0): #291-#322
...
```

Example output with -H:
```
ghwdump -H waves.ghw
...
instance /bench/lfsr:
port-in /bench/lfsr/clk: std_logic: #1
port-in /bench/lfsr/rst: std_logic: #2
port-in /bench/lfsr/off: std_logic: #46
port-in /bench/lfsr/seed: std_logic_vector (31 downto 0): #47-#78
port-out /bench/lfsr/val: std_logic_vector (31 downto 0): #79-#110
signal /bench/lfsr/s0: std_logic_vector (31 downto 0): #195-#226
signal /bench/lfsr/s1: std_logic_vector (31 downto 0): #227-#258
signal /bench/lfsr/s2: std_logic_vector (31 downto 0): #259-#290
signal /bench/lfsr/s3: std_logic_vector (31 downto 0): #291-#322
...
```
