### PR TITLE
Fix PowerShell based build flow

### DIFF
--- a/dist/windows/mcode/binary_file-format.ads
+++ b/dist/windows/mcode/binary_file-format.ads
@@ -1,0 +1,3 @@
+with Binary_File.Coff;
+
+package Binary_File.Format renames Binary_File.Coff;

--- a/dist/windows/mcode/default_pathes.ads
+++ b/dist/windows/mcode/default_pathes.ads
@@ -1,0 +1,9 @@
+with Windows_Default_Path;
+pragma Elaborate_All (Windows_Default_Path);
+
+package Default_Pathes is
+   Install_Prefix : constant String :=
+     Windows_Default_Path.Get_Windows_Exec_Path;
+   Lib_Prefix : constant String := "lib";
+   Shared_Library_Extension : constant String := ".dll";
+end Default_Pathes;

--- a/dist/windows/mcode/grt-backtraces-impl.ads
+++ b/dist/windows/mcode/grt-backtraces-impl.ads
@@ -1,0 +1,3 @@
+with Grt.Backtraces.Jit;
+
+package Grt.Backtraces.Impl renames Grt.Backtraces.Jit;


### PR DESCRIPTION
**This PR fixes:**
* the PowerShell based build flow

**It changes:**
* added 3 missing files in `dist\windows\mcode`
  * binary_file-format.ads
  * default_pathes.ads
  * grt-backtraces-impl.ads

**Required changes by @tgingold:**
* add appropriate file headers