### PR TITLE
Freebsd configure

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -187,10 +187,10 @@ gcc_vhdl_dir=$(gcc_src_dir)/gcc/vhdl
 
 all.gcc:
 	@echo "For installing sources in gcc, do:"
-	@echo "1) make copy-sources"
+	@echo "1) $(MAKE) copy-sources"
 	@echo "2) configure, build and install gcc"
-	@echo "3) make ghdllib"
-	@echo "4) make install"
+	@echo "3) $(MAKE) ghdllib"
+	@echo "4) $(MAKE) install"
 
 copy-sources.gcc: version.ads
 	$(RM) -rf $(gcc_vhdl_dir)

--- a/configure
+++ b/configure
@@ -8,6 +8,7 @@ CC=${CC:-gcc}
 CXX=${CXX:-clang++}
 CFLAGS=${CFLAGS:--g}
 GNATMAKE=${GNATMAKE:-gnatmake}
+MAKE=${MAKE:-make}
 LDFLAGS=
 prefix=/usr/local
 libdirsuffix=lib/ghdl
@@ -299,7 +300,7 @@ if ! sh ./config.status; then
 fi
 
 # Create dirs
-make create-dirs
+$MAKE create-dirs
 
 # Generate ortho_code-x86-flags
 if test $backend = mcode; then


### PR DESCRIPTION
User convenience when building GHDL on FreeBSD.

With these patches, GHDL/LLVM can be built on FreeBSD 11.1 with:
```
$ mkdir build && cd build
$ ../configure --prefix=/opt/ghdl-0.35-llvm --with-llvm-config=/usr/local/llvm40/bin/llvm-config --with-gnatmake=/usr/local/gcc6-aux/bin/gnatmake
$ gmake
$ gmake install
```